### PR TITLE
feat: Add configurable port for openhands serve

### DIFF
--- a/openhands_cli/argparsers/serve_parser.py
+++ b/openhands_cli/argparsers/serve_parser.py
@@ -28,4 +28,10 @@ def add_serve_parser(subparsers: argparse._SubParsersAction) -> argparse.Argumen
         action="store_true",
         default=False,
     )
+    serve_parser.add_argument(
+        "--port",
+        help="Port on the host to expose the OpenHands GUI server",
+        type=int,
+        default=3000,
+    )
     return serve_parser

--- a/openhands_cli/entrypoint.py
+++ b/openhands_cli/entrypoint.py
@@ -123,7 +123,7 @@ def main() -> None:
             # Import gui_launcher only when needed
             from openhands_cli.gui_launcher import launch_gui_server
 
-            launch_gui_server(mount_cwd=args.mount_cwd, gpu=args.gpu)
+            launch_gui_server(mount_cwd=args.mount_cwd, gpu=args.gpu, port=args.port)
         elif args.command == "web":
             # Import web server launcher only when needed
             from openhands_cli.tui.serve import launch_web_server

--- a/openhands_cli/gui_launcher.py
+++ b/openhands_cli/gui_launcher.py
@@ -88,13 +88,16 @@ def get_openhands_version() -> str:
     return os.environ.get("OPENHANDS_VERSION", "latest")
 
 
-def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
+def launch_gui_server(
+    mount_cwd: bool = False, gpu: bool = False, port: int = 3000
+) -> None:
     """Launch the OpenHands GUI server using Docker.
 
     Args:
         mount_cwd: If True, mount the current working directory into the container.
         gpu: If True, enable GPU support by mounting all GPUs into the
             container via nvidia-docker.
+        port: Host port to expose the OpenHands GUI server on.
     """
     console.print("🚀 Launching OpenHands GUI server...", style="blue", markup=False)
     console.print()
@@ -117,7 +120,7 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
 
     console.print("✅ Starting OpenHands GUI server...", style="green", markup=False)
     console.print(
-        "The server will be available at: http://localhost:3000",
+        f"The server will be available at: http://localhost:{port}",
         style="grey50",
         markup=False,
     )
@@ -187,7 +190,7 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
     docker_cmd.extend(
         [
             "-p",
-            "3000:3000",
+            f"{port}:3000",
             "--add-host",
             "host.docker.internal:host-gateway",
             "--name",

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -118,7 +118,7 @@ class TestLaunchGuiServer:
         assert exc_info.value.code == 1
 
     @pytest.mark.parametrize(
-        "run_side_effect,expected_exit_code,mount_cwd,gpu,port,expected_port_mapping",
+        "run_side_effect,expected_exit_code,mount_cwd,gpu,port,port_mapping",
         [
             # Docker run failure
             (
@@ -160,7 +160,7 @@ class TestLaunchGuiServer:
         mount_cwd,
         gpu,
         port,
-        expected_port_mapping,
+        port_mapping,
     ):
         """Test various GUI server launch scenarios."""
         # Setup mocks
@@ -194,7 +194,7 @@ class TestLaunchGuiServer:
             assert run_cmd[0:2] == ["docker", "run"]
             # Verify --pull=always is in the command
             assert "--pull=always" in run_cmd
-            assert expected_port_mapping in run_cmd
+            assert port_mapping in run_cmd
 
             if mount_cwd:
                 assert "SANDBOX_VOLUMES=/current/dir:/workspace:rw" in " ".join(run_cmd)

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -118,16 +118,25 @@ class TestLaunchGuiServer:
         assert exc_info.value.code == 1
 
     @pytest.mark.parametrize(
-        "run_side_effect,expected_exit_code,mount_cwd,gpu",
+        "run_side_effect,expected_exit_code,mount_cwd,gpu,port,expected_port_mapping",
         [
             # Docker run failure
-            (subprocess.CalledProcessError(1, "docker run"), 1, False, False),
+            (
+                subprocess.CalledProcessError(1, "docker run"),
+                1,
+                False,
+                False,
+                3000,
+                None,
+            ),
             # KeyboardInterrupt during run
-            (KeyboardInterrupt(), 0, False, False),
+            (KeyboardInterrupt(), 0, False, False, 3000, None),
             # Success with mount_cwd
-            (MagicMock(returncode=0), None, True, False),
+            (MagicMock(returncode=0), None, True, False, 3000, "3000:3000"),
             # Success with GPU
-            (MagicMock(returncode=0), None, False, True),
+            (MagicMock(returncode=0), None, False, True, 3000, "3000:3000"),
+            # Success with custom host port
+            (MagicMock(returncode=0), None, False, False, 4000, "4000:3000"),
         ],
     )
     @patch("openhands_cli.gui_launcher.check_docker_requirements")
@@ -150,6 +159,8 @@ class TestLaunchGuiServer:
         expected_exit_code,
         mount_cwd,
         gpu,
+        port,
+        expected_port_mapping,
     ):
         """Test various GUI server launch scenarios."""
         # Setup mocks
@@ -168,11 +179,11 @@ class TestLaunchGuiServer:
         # Test the function
         if expected_exit_code is not None:
             with pytest.raises(SystemExit) as exc_info:
-                launch_gui_server(mount_cwd=mount_cwd, gpu=gpu)
+                launch_gui_server(mount_cwd=mount_cwd, gpu=gpu, port=port)
             assert exc_info.value.code == expected_exit_code
         else:
             # Should not raise SystemExit for successful cases
-            launch_gui_server(mount_cwd=mount_cwd, gpu=gpu)
+            launch_gui_server(mount_cwd=mount_cwd, gpu=gpu, port=port)
 
             # Verify subprocess.run was called once (only docker run, no separate pull)
             assert mock_run.call_count == 1
@@ -183,6 +194,7 @@ class TestLaunchGuiServer:
             assert run_cmd[0:2] == ["docker", "run"]
             # Verify --pull=always is in the command
             assert "--pull=always" in run_cmd
+            assert expected_port_mapping in run_cmd
 
             if mount_cwd:
                 assert "SANDBOX_VOLUMES=/current/dir:/workspace:rw" in " ".join(run_cmd)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -311,12 +311,22 @@ def test_main_cli_file_takes_precedence_over_task(monkeypatch, tmp_path):
 @pytest.mark.parametrize(
     "argv,expected_kwargs",
     [
-        (["openhands", "serve"], {"mount_cwd": False, "gpu": False}),
-        (["openhands", "serve", "--mount-cwd"], {"mount_cwd": True, "gpu": False}),
-        (["openhands", "serve", "--gpu"], {"mount_cwd": False, "gpu": True}),
+        (["openhands", "serve"], {"mount_cwd": False, "gpu": False, "port": 3000}),
+        (
+            ["openhands", "serve", "--mount-cwd"],
+            {"mount_cwd": True, "gpu": False, "port": 3000},
+        ),
+        (
+            ["openhands", "serve", "--gpu"],
+            {"mount_cwd": False, "gpu": True, "port": 3000},
+        ),
+        (
+            ["openhands", "serve", "--port", "4000"],
+            {"mount_cwd": False, "gpu": False, "port": 4000},
+        ),
         (
             ["openhands", "serve", "--mount-cwd", "--gpu"],
-            {"mount_cwd": True, "gpu": True},
+            {"mount_cwd": True, "gpu": True, "port": 3000},
         ),
     ],
 )


### PR DESCRIPTION
## Summary

Fixes #779

Adds a `--port` option to `openhands serve` so users can access the OpenHands GUI container on a custom host port.

The Docker container still listens on port `3000`; only made the host-side Docker port configurable.

Example:

```bash
openhands serve --port 4000
```
 Docker runs with:    `-p 4000:3000`

## Testing

- `uv run pytest tests/test_main.py::test_main_serve_calls_launch_gui_server tests/test_gui_launcher.py::TestLaunchGuiServer::test_launch_gui_server_scenarios`
- Manually verified `openhands serve --port 4000` in Docker as `0.0.0.0:4000->3000/tcp`