### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!-- Keep this PR as draft until it is ready for review. -->
+
+## Why
+
+<!-- Describe the problem or motivation for this change. -->
+
+## Summary
+
+<!-- 1-3 bullets describing what changed. -->
+-
+
+## Issue Number
+
+<!-- Link the related issue, e.g. Fixes #123 -->
+
+## How to Test
+
+<!--
+Required. Share the steps for the reviewer to test your PR, e.g.
+`uv sync` then `uv run openhands`.
+
+If you could not test this, say why.
+-->
+
+## Video/Screenshots
+
+<!-- Provide a video or screenshots if this changes CLI behavior or output. -->
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Breaking change
+- [ ] Docs / chore
+
+## Notes
+
+<!-- Optional: migrations, config changes, rollout concerns, follow-ups, or anything reviewers should know. -->


### PR DESCRIPTION
## Why

This repo had no pull request template, unlike the main OpenHands repo.

## Summary
- Add `.github/pull_request_template.md`, adapted from the main OpenHands repo's template for this CLI repo

## Issue Number

Closes #652

## How to Test

N/A, template only. Opening this PR will populate its description from the new template.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore