### PR TITLE
feat: add --port flag to openhands serve

### DIFF
--- a/openhands_cli/argparsers/serve_parser.py
+++ b/openhands_cli/argparsers/serve_parser.py
@@ -28,4 +28,10 @@ def add_serve_parser(subparsers: argparse._SubParsersAction) -> argparse.Argumen
         action="store_true",
         default=False,
     )
+    serve_parser.add_argument(
+        "--port",
+        help="Host port to bind the GUI server to (default: 3000)",
+        type=int,
+        default=3000,
+    )
     return serve_parser

--- a/openhands_cli/entrypoint.py
+++ b/openhands_cli/entrypoint.py
@@ -123,7 +123,7 @@ def main() -> None:
             # Import gui_launcher only when needed
             from openhands_cli.gui_launcher import launch_gui_server
 
-            launch_gui_server(mount_cwd=args.mount_cwd, gpu=args.gpu)
+            launch_gui_server(mount_cwd=args.mount_cwd, gpu=args.gpu, port=args.port)
         elif args.command == "web":
             # Import web server launcher only when needed
             from openhands_cli.tui.serve import launch_web_server

--- a/openhands_cli/gui_launcher.py
+++ b/openhands_cli/gui_launcher.py
@@ -88,13 +88,16 @@ def get_openhands_version() -> str:
     return os.environ.get("OPENHANDS_VERSION", "latest")
 
 
-def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
+def launch_gui_server(
+    mount_cwd: bool = False, gpu: bool = False, port: int = 3000
+) -> None:
     """Launch the OpenHands GUI server using Docker.
 
     Args:
         mount_cwd: If True, mount the current working directory into the container.
         gpu: If True, enable GPU support by mounting all GPUs into the
             container via nvidia-docker.
+        port: Host port to bind the GUI server to.
     """
     console.print("🚀 Launching OpenHands GUI server...", style="blue", markup=False)
     console.print()
@@ -117,7 +120,7 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
 
     console.print("✅ Starting OpenHands GUI server...", style="green", markup=False)
     console.print(
-        "The server will be available at: http://localhost:3000",
+        f"The server will be available at: http://localhost:{port}",
         style="grey50",
         markup=False,
     )
@@ -187,7 +190,7 @@ def launch_gui_server(mount_cwd: bool = False, gpu: bool = False) -> None:
     docker_cmd.extend(
         [
             "-p",
-            "3000:3000",
+            f"{port}:3000",
             "--add-host",
             "host.docker.internal:host-gateway",
             "--name",

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -192,3 +192,28 @@ class TestLaunchGuiServer:
                 assert "--gpus" in run_cmd
                 assert "all" in run_cmd
                 assert "SANDBOX_ENABLE_GPU=true" in " ".join(run_cmd)
+
+    @patch("openhands_cli.gui_launcher.check_docker_requirements")
+    @patch("openhands_cli.gui_launcher.ensure_config_dir_exists")
+    @patch("openhands_cli.gui_launcher.get_openhands_version")
+    @patch("subprocess.run")
+    @patch("openhands_cli.gui_launcher.console.print")
+    def test_launch_gui_server_custom_port(
+        self,
+        mock_print,
+        mock_run,
+        mock_version,
+        mock_config_dir,
+        mock_check_docker,
+    ):
+        """Test that a custom port maps host:port to the container's port 3000."""
+        mock_check_docker.return_value = True
+        mock_config_dir.return_value = Path("/home/user/.openhands")
+        mock_version.return_value = "latest"
+        mock_run.return_value = MagicMock(returncode=0)
+
+        launch_gui_server(port=4000)
+
+        docker_cmd = mock_run.call_args[0][0]
+        assert "-p" in docker_cmd
+        assert docker_cmd[docker_cmd.index("-p") + 1] == "4000:3000"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -311,12 +311,22 @@ def test_main_cli_file_takes_precedence_over_task(monkeypatch, tmp_path):
 @pytest.mark.parametrize(
     "argv,expected_kwargs",
     [
-        (["openhands", "serve"], {"mount_cwd": False, "gpu": False}),
-        (["openhands", "serve", "--mount-cwd"], {"mount_cwd": True, "gpu": False}),
-        (["openhands", "serve", "--gpu"], {"mount_cwd": False, "gpu": True}),
+        (["openhands", "serve"], {"mount_cwd": False, "gpu": False, "port": 3000}),
+        (
+            ["openhands", "serve", "--mount-cwd"],
+            {"mount_cwd": True, "gpu": False, "port": 3000},
+        ),
+        (
+            ["openhands", "serve", "--gpu"],
+            {"mount_cwd": False, "gpu": True, "port": 3000},
+        ),
         (
             ["openhands", "serve", "--mount-cwd", "--gpu"],
-            {"mount_cwd": True, "gpu": True},
+            {"mount_cwd": True, "gpu": True, "port": 3000},
+        ),
+        (
+            ["openhands", "serve", "--port", "4000"],
+            {"mount_cwd": False, "gpu": False, "port": 4000},
         ),
     ],
 )


### PR DESCRIPTION
## Why

`openhands serve` hardcodes host port 3000 for the Docker container (`-p 3000:3000`), with no way to override it. Since 3000 is also the default dev-server port for many frontend frameworks (Next.js, Vite, CRA), this creates a port conflict for developers who want to run OpenHands alongside their own project.

## Summary
- Add `--port <PORT>` option to `openhands serve`, default 3000
- Map host `--port` to the container's fixed port 3000 (`-p <PORT>:3000`)
- Update the printed "server will be available at" URL to reflect the chosen port

## Issue Number

Closes #779

## How to Test

`openhands serve --port 4000` should start the container with `-p 4000:3000` and print `http://localhost:4000`. `openhands serve` with no flag keeps the previous default of 3000.

Added a unit test (`test_launch_gui_server_custom_port`) asserting the docker command maps `4000:3000`, and updated the existing `test_main_serve_calls_launch_gui_server` parametrization to cover the new kwarg. Full test suite run locally: 1402 passed.

## Type

- [x] Feature

## Notes

No change to default behavior; `--port` is optional and defaults to 3000.