### PR TITLE
Chore/bump openhands sdk 1.41.0

### DIFF
--- a/openhands_cli/acp_impl/agent/base_agent.py
+++ b/openhands_cli/acp_impl/agent/base_agent.py
@@ -26,8 +26,9 @@ from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
     AuthenticateResponse,
-    AuthMethod,
+    AuthMethodAgent,
     AvailableCommandsUpdate,
+    EnvVarAuthMethod,
     ForkSessionResponse,
     Implementation,
     ListSessionsResponse,
@@ -38,6 +39,7 @@ from acp.schema import (
     SetSessionConfigOptionResponse,
     SetSessionModelResponse,
     SetSessionModeResponse,
+    TerminalAuthMethod,
     TextContentBlock,
 )
 
@@ -232,8 +234,8 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
         logger.info(f"Initializing ACP with protocol version: {protocol_version}")
 
         # Always configure auth method
-        auth_methods = [
-            AuthMethod(
+        auth_methods: list[EnvVarAuthMethod | TerminalAuthMethod | AuthMethodAgent] = [
+            AuthMethodAgent(
                 description="Authenticate through agent",
                 id="oauth",
                 name="OAuth with OpenHands Cloud",
@@ -292,6 +294,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
 
     async def list_sessions(
         self,
+        additional_directories: list[str] | None = None,  # noqa: ARG002
         cursor: str | None = None,  # noqa: ARG002
         cwd: str | None = None,  # noqa: ARG002
         **_kwargs: Any,
@@ -342,7 +345,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
         self,
         config_id: str,  # noqa: ARG002
         session_id: str,  # noqa: ARG002
-        value: str,  # noqa: ARG002
+        value: str | bool,  # noqa: ARG002
         **_kwargs: Any,
     ) -> SetSessionConfigOptionResponse | None:
         """Set config option (not supported)."""
@@ -352,6 +355,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
         self,
         cwd: str,  # noqa: ARG002
         session_id: str,  # noqa: ARG002
+        additional_directories: list[str] | None = None,  # noqa: ARG002
         mcp_servers: list[Any] | None = None,  # noqa: ARG002
         **_kwargs: Any,
     ) -> ForkSessionResponse:
@@ -362,6 +366,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
         self,
         cwd: str,  # noqa: ARG002
         session_id: str,  # noqa: ARG002
+        additional_directories: list[str] | None = None,  # noqa: ARG002
         mcp_servers: list[Any] | None = None,  # noqa: ARG002
         **_kwargs: Any,
     ) -> ResumeSessionResponse:
@@ -427,9 +432,15 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
                 {"reason": "Failed to cancel session", "details": str(e)}
             )
 
+    async def close_session(self, session_id: str, **_kwargs: Any) -> None:
+        """Close a session and clean up resources."""
+        logger.info(f"Closing session: {session_id}")
+        self._cleanup_session(session_id)
+
     async def new_session(
         self,
         cwd: str,  # noqa: ARG002
+        additional_directories: list[str] | None = None,  # noqa: ARG002
         mcp_servers: list[Any] | None = None,
         working_dir: str | None = None,
         **_kwargs: Any,
@@ -438,6 +449,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
 
         Args:
             cwd: Current working directory (from ACP protocol)
+            additional_directories: Additional directories (from ACP protocol)
             mcp_servers: ACP MCP servers configuration
             working_dir: Working directory override (for local sessions)
 
@@ -515,7 +527,11 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
             )
 
     async def prompt(
-        self, prompt: list[Any], session_id: str, **_kwargs: Any
+        self,
+        prompt: list[Any],
+        session_id: str,
+        message_id: str | None = None,  # noqa: ARG002
+        **_kwargs: Any,
     ) -> PromptResponse:
         """Handle a prompt request with slash command support.
 
@@ -601,6 +617,7 @@ class BaseOpenHandsACPAgent(ACPAgent, ABC):
         self,
         cwd: str,  # noqa: ARG002
         session_id: str,
+        additional_directories: list[str] | None = None,  # noqa: ARG002
         mcp_servers: list[Any] | None = None,  # noqa: ARG002
         **_kwargs: Any,
     ) -> LoadSessionResponse | None:

--- a/openhands_cli/acp_impl/agent/local_agent.py
+++ b/openhands_cli/acp_impl/agent/local_agent.py
@@ -201,6 +201,7 @@ class LocalOpenHandsACPAgent(BaseOpenHandsACPAgent):
     async def new_session(
         self,
         cwd: str,
+        additional_directories: list[str] | None = None,  # noqa: ARG002
         mcp_servers: list[Any] | None = None,
         working_dir: str | None = None,
         **_kwargs: Any,
@@ -218,6 +219,7 @@ class LocalOpenHandsACPAgent(BaseOpenHandsACPAgent):
 
         return await super().new_session(
             cwd=cwd,
+            additional_directories=additional_directories,
             mcp_servers=mcp_servers,
             working_dir=effective_working_dir,
             **_kwargs,

--- a/openhands_cli/acp_impl/agent/remote_agent.py
+++ b/openhands_cli/acp_impl/agent/remote_agent.py
@@ -261,6 +261,7 @@ class OpenHandsCloudACPAgent(BaseOpenHandsACPAgent):
     async def new_session(
         self,
         cwd: str,
+        additional_directories: list[str] | None = None,  # noqa: ARG002
         mcp_servers: list[Any] | None = None,
         working_dir: str | None = None,
         **_kwargs: Any,
@@ -274,11 +275,19 @@ class OpenHandsCloudACPAgent(BaseOpenHandsACPAgent):
             )
 
         return await super().new_session(
-            cwd=cwd, mcp_servers=mcp_servers, working_dir=working_dir, **_kwargs
+            cwd=cwd,
+            additional_directories=additional_directories,
+            mcp_servers=mcp_servers,
+            working_dir=working_dir,
+            **_kwargs,
         )
 
     async def prompt(
-        self, prompt: list[Any], session_id: str, **_kwargs: Any
+        self,
+        prompt: list[Any],
+        session_id: str,
+        message_id: str | None = None,  # noqa: ARG002
+        **_kwargs: Any,
     ) -> PromptResponse:
         """Handle a prompt request with cloud workspace.
 
@@ -300,12 +309,13 @@ class OpenHandsCloudACPAgent(BaseOpenHandsACPAgent):
             )
 
         # Call base class prompt implementation
-        return await super().prompt(prompt, session_id, **_kwargs)
+        return await super().prompt(prompt, session_id, message_id, **_kwargs)
 
     async def load_session(
         self,
         cwd: str,  # noqa: ARG002
         session_id: str,
+        additional_directories: list[str] | None = None,  # noqa: ARG002
         mcp_servers: list[Any] | None = None,  # noqa: ARG002
         **_kwargs: Any,
     ) -> LoadSessionResponse | None:

--- a/openhands_cli/acp_impl/utils/mcp.py
+++ b/openhands_cli/acp_impl/utils/mcp.py
@@ -18,7 +18,8 @@ def _convert_env_to_dict(env: Sequence[dict[str, str]]) -> dict[str, str]:
     Convert environment variables from serialized EnvVariable format to a dictionary.
 
     When Pydantic models are dumped to dict, EnvVariable objects become dicts
-    with 'name' and 'value' keys.
+    with 'name' and 'value' keys. ACP HTTP/SSE server headers use the same
+    serialized shape, so this helper converts those as well.
 
     Args:
         env: List of dicts with 'name' and 'value' keys (serialized EnvVariable objects)
@@ -52,15 +53,20 @@ def convert_acp_mcp_servers_to_agent_format(
 
     for server in mcp_servers:
         server_dict = server.model_dump()
-        server_name: str = server_dict["name"]
-        server_config: dict[str, Any] = {
-            k: v for k, v in server_dict.items() if k != "name"
-        }
+        server_name: str = server_dict.pop("name")
+        # Drop ACP schema metadata; the SDK's MCPServer model forbids extras
+        server_dict.pop("field_meta", None)
+        server_dict.pop("type", None)
+        server_config: dict[str, Any] = server_dict
 
         # Convert env from array to dict format if present
         # ACP sends env as array of EnvVariable objects, but Agent expects dict
         if "env" in server_config:
             server_config["env"] = _convert_env_to_dict(server_config["env"])
+
+        # ACP sends headers as an array of EnvVariable-shaped objects too
+        if "headers" in server_config:
+            server_config["headers"] = _convert_env_to_dict(server_config["headers"])
 
         # Add transport type based on server class
         # StdioMcpServer -> stdio, HttpMcpServer -> http, SseMcpServer -> sse

--- a/openhands_cli/mcp/mcp_display_utils.py
+++ b/openhands_cli/mcp/mcp_display_utils.py
@@ -4,46 +4,6 @@ This module provides shared utilities for formatting MCP server
 configuration details across different display contexts (CLI, TUI, etc.).
 """
 
-from typing import Any
-
-from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
-
-
-def normalize_server_object(
-    server: StdioMCPServer | RemoteMCPServer | dict[str, Any],
-) -> StdioMCPServer | RemoteMCPServer:
-    """Convert dict format to FastMCP server object if needed.
-
-    Handles both FastMCP objects and legacy dict format for compatibility.
-    Detects server type based on transport field or presence of command vs url.
-
-    Args:
-        server: Server configuration as FastMCP object or dict
-
-    Returns:
-        FastMCP server object (StdioMCPServer or RemoteMCPServer)
-    """
-    if isinstance(server, dict):
-        # Legacy dict format - convert to appropriate server object for processing
-        # Detect server type based on transport field or presence of command vs url
-        if server.get("transport") == "stdio" or (
-            "command" in server and "url" not in server
-        ):
-            # Add default transport if missing for StdioMCPServer
-            server_dict = server.copy()
-            if "transport" not in server_dict:
-                server_dict["transport"] = "stdio"
-            return StdioMCPServer(**server_dict)
-        else:
-            # Add default transport if missing for RemoteMCPServer
-            server_dict = server.copy()
-            if "transport" not in server_dict:
-                server_dict["transport"] = "http"
-            return RemoteMCPServer(**server_dict)
-    else:
-        # Already a FastMCP object
-        return server
-
 
 def mask_sensitive_value(key: str, value: str) -> str:
     """Mask potentially sensitive values in configuration display.

--- a/openhands_cli/setup.py
+++ b/openhands_cli/setup.py
@@ -8,6 +8,7 @@ from openhands.sdk import Agent, AgentContext, BaseConversation, Conversation, W
 from openhands.sdk.context import Skill
 from openhands.sdk.event.base import Event
 from openhands.sdk.hooks import HookConfig
+from openhands.sdk.mcp.config import MCPServer
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
@@ -65,12 +66,10 @@ def load_agent_specs(
     # If MCP servers are provided, augment the agent's MCP configuration
     if mcp_servers:
         # Merge with existing MCP configuration (provided servers take precedence)
-        mcp_config: dict[str, Any] = agent.mcp_config or {}
-        existing_servers: dict[str, dict[str, Any]] = mcp_config.get("mcpServers", {})
-        existing_servers.update(mcp_servers)
-        agent = agent.model_copy(
-            update={"mcp_config": {"mcpServers": existing_servers}}
-        )
+        existing_servers = dict(agent.mcp_config or {})
+        for name, server_spec in mcp_servers.items():
+            existing_servers[name] = MCPServer.model_validate(server_spec)
+        agent = agent.model_copy(update={"mcp_config": existing_servers})
 
     if skills:
         if agent.agent_context is not None:

--- a/openhands_cli/stores/agent_store.py
+++ b/openhands_cli/stores/agent_store.py
@@ -6,7 +6,7 @@ import os
 import re
 from typing import Any
 
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, SecretStr, ValidationError
 from rich.console import Console
 
 from openhands.sdk import (
@@ -20,6 +20,7 @@ from openhands.sdk.context import load_project_skills
 from openhands.sdk.conversation.persistence_const import BASE_STATE
 from openhands.sdk.critic.base import CriticBase
 from openhands.sdk.critic.impl.api import APIBasedCritic
+from openhands.sdk.mcp.config import MCPServer, coerce_mcp_config
 from openhands.sdk.tool import Tool
 from openhands_cli.deprecated_utils import conversation_has_delegate_tool
 from openhands_cli.locations import (
@@ -42,6 +43,60 @@ from openhands_cli.utils import (
 
 console = Console(highlight=False, soft_wrap=True)
 stderr_console = Console(stderr=True, highlight=False, soft_wrap=True)
+
+
+def _auth_string_to_credential(auth: str) -> dict[str, Any]:
+    """Translate a fastmcp-style ``auth`` string to an SDK auth credential.
+
+    fastmcp's ``RemoteMCPServer.auth`` accepts plain strings (``"oauth"`` or a
+    bearer token); the SDK models auth as a discriminated credential union.
+    This is the inverse of the SDK's fastmcp export mapping.
+    """
+    if auth == "oauth":
+        return {"strategy": "oauth2"}
+    return {"strategy": "bearer", "value": auth}
+
+
+def convert_mcp_servers(
+    servers: dict[str, Any] | None,
+) -> dict[str, MCPServer]:
+    """Convert MCP server specs to the SDK's ``dict[str, MCPServer]`` format.
+
+    openhands-sdk >= 1.32 changed ``Agent.mcp_config`` from an opaque dict to
+    ``dict[str, MCPServer]`` (no ``"mcpServers"`` wrapper). This normalizes the
+    fastmcp server objects produced by :func:`list_enabled_servers` into that
+    format, and also tolerates the pre-1.32 wrapped dict found in persisted
+    agent settings.
+
+    Args:
+        servers: Mapping of server name to fastmcp server object, SDK
+            ``MCPServer``, or raw dict -- or a legacy ``{"mcpServers": ...}``
+            wrapper around such a mapping. ``None`` yields an empty dict.
+
+    Returns:
+        Mapping of server name to SDK ``MCPServer``.
+
+    Raises:
+        ValidationError: If a server spec cannot be validated as an
+            ``MCPServer``.
+    """
+    if not servers:
+        return {}
+    # Unwrap the pre-1.32 {"mcpServers": ...} container if that is all there is
+    if set(servers) == {"mcpServers"} and isinstance(servers["mcpServers"], dict):
+        servers = servers["mcpServers"]
+    raw: dict[str, Any] = {}
+    for name, server in servers.items():
+        if isinstance(server, MCPServer):
+            raw[name] = server
+            continue
+        data = server if isinstance(server, dict) else server.model_dump()
+        if isinstance(data.get("auth"), str):
+            data = {**data, "auth": _auth_string_to_credential(data["auth"])}
+        raw[name] = data
+    # The SDK's coercion drops fastmcp-only fields (`type`, `authentication`,
+    # ...) and normalizes transport spellings before validation.
+    return coerce_mcp_config(raw)
 
 
 def get_persisted_conversation_tools(conversation_id: str) -> list[Tool] | None:
@@ -263,6 +318,12 @@ class AgentStore:
     def load_from_disk(self) -> Agent | None:
         """Load an agent configuration from disk storage.
 
+        A persisted ``mcp_config`` -- whether a stale flat dict or the pre-1.32
+        ``{"mcpServers": ...}`` wrapper -- is coerced to the flat
+        ``dict[str, MCPServer]`` format so validation succeeds. ``mcp.json``
+        remains the single source of truth for MCP servers (see
+        ``_apply_runtime_config``).
+
         This method only loads the persisted agent configuration. It does not
         apply runtime configuration or create agents from environment variables.
 
@@ -272,10 +333,35 @@ class AgentStore:
         """
         try:
             str_spec = self.file_store.read(AGENT_SETTINGS_PATH)
-            # Respects user choices persisted in agent_settings.json on disk.
-            return Agent.model_validate_json(str_spec)
         except FileNotFoundError:
             return None
+        try:
+            data = json.loads(str_spec)
+        except (ValueError, TypeError):
+            console.print(
+                "\nAgent configuration file is corrupted!",
+                style="red",
+                markup=False,
+            )
+            return None
+        if not isinstance(data, dict):
+            console.print(
+                "\nAgent configuration file is corrupted!",
+                style="red",
+                markup=False,
+            )
+            return None
+        # Coerce any persisted MCP config to the flat dict[str, MCPServer]
+        # format (dropping the pre-1.32 {"mcpServers": ...} wrapper). Note
+        # mcp.json remains the source of truth: _apply_runtime_config rebuilds
+        # mcp_config from it. A persisted MCP value that cannot be coerced is
+        # dropped rather than failing the whole load.
+        try:
+            data["mcp_config"] = convert_mcp_servers(data.get("mcp_config"))
+        except ValidationError:
+            data["mcp_config"] = {}
+        try:
+            return Agent.model_validate(data)
         except Exception:
             console.print(
                 "\nAgent configuration file is corrupted!",
@@ -449,7 +535,7 @@ class AgentStore:
         agent_context = self._build_agent_context()
 
         enabled_servers = list_enabled_servers()
-        mcp_config = {"mcpServers": enabled_servers} if enabled_servers else {}
+        mcp_config = convert_mcp_servers(enabled_servers)
 
         condenser = self._maybe_build_condenser(agent, session_id=session_id)
 

--- a/openhands_cli/tui/panels/mcp_side_panel.py
+++ b/openhands_cli/tui/panels/mcp_side_panel.py
@@ -1,18 +1,17 @@
 """MCP side panel widget for displaying MCP server information."""
 
 import json
-from typing import Any
 
-from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, VerticalScroll
 from textual.css.query import NoMatches
 from textual.widgets import Static
 
 from openhands.sdk import Agent
+from openhands.sdk.mcp.config import MCPServer, dump_mcp_config
 from openhands_cli.locations import MCP_CONFIG_FILE
-from openhands_cli.mcp.mcp_display_utils import normalize_server_object
 from openhands_cli.mcp.mcp_utils import get_config_status
+from openhands_cli.stores.agent_store import convert_mcp_servers
 from openhands_cli.theme import OPENHANDS_THEME
 from openhands_cli.tui.panels.mcp_panel_style import MCP_PANEL_STYLE
 
@@ -91,7 +90,8 @@ class MCPSidePanel(VerticalScroll):
 
         # Get MCP configuration status
         status = get_config_status()
-        current_servers = self.agent.mcp_config.get("mcpServers", {})
+        # agent.mcp_config is a flat {name: MCPServer} dict in openhands-sdk >= 1.32
+        current_servers = self.agent.mcp_config or {}
 
         # Build content string
         content_parts = []
@@ -171,43 +171,45 @@ class MCPSidePanel(VerticalScroll):
         content_text = "\n".join(content_parts)
         content_widget.update(content_text)
 
-    def _format_server_details(
-        self, server: StdioMCPServer | RemoteMCPServer | dict[str, Any]
-    ) -> list[str]:
-        """Format server specification details for display."""
+    def _format_server_details(self, server: MCPServer) -> list[str]:
+        """Format an ``MCPServer`` for display in the side panel."""
         details = []
 
-        # Convert to FastMCP object if needed
-        server_obj = normalize_server_object(server)
-
-        if isinstance(server_obj, StdioMCPServer):
+        if server.command or (server.transport or "").lower() == "stdio":
             details.append("Type: Command-based")
-            if server_obj.command or server_obj.args:
-                command_parts = [server_obj.command] if server_obj.command else []
-                if server_obj.args:
-                    command_parts.extend(server_obj.args)
+            if server.command or server.args:
+                command_parts = [server.command] if server.command else []
+                if server.args:
+                    command_parts.extend(server.args)
                 command_str = " ".join(command_parts)
                 if command_str:
                     details.append(f"Command: {command_str}")
-        elif isinstance(server_obj, RemoteMCPServer):
+        else:
             details.append("Type: URL-based")
-            if server_obj.url:
-                details.append(f"URL: {server_obj.url}")
-            details.append(f"Auth: {server_obj.auth or 'none'}")
+            if server.url:
+                details.append(f"URL: {server.url}")
+            auth_strategy = getattr(server.auth, "strategy", None)
+            if auth_strategy == "oauth2":
+                # Show the spelling used in mcp.json, not the SDK enum name
+                auth_strategy = "oauth"
+            details.append(f"Auth: {auth_strategy or 'none'}")
 
         return details
 
-    def _server_spec_to_dict(
-        self, server_spec: StdioMCPServer | RemoteMCPServer | dict
-    ) -> dict:
+    def _server_spec_to_dict(self, server_spec: MCPServer | dict) -> dict:
         """Convert a server specification to a dictionary for comparison.
 
-        Handles both Pydantic model objects (StdioMCPServer, RemoteMCPServer)
-        and plain dictionaries.
+        Current servers are SDK ``MCPServer`` objects; incoming servers from
+        ``mcp.json`` are raw dicts. Both are funneled through the same
+        coercion/dump pipeline so the comparison is apples-to-apples.
         """
-        if isinstance(server_spec, StdioMCPServer | RemoteMCPServer):
-            return server_spec.model_dump()
-        return server_spec
+        if not isinstance(server_spec, MCPServer):
+            try:
+                server_spec = convert_mcp_servers({"server": server_spec})["server"]
+            except Exception:
+                # Uncoercible spec: compare raw, which reports it as changed
+                return server_spec
+        return dump_mcp_config({"server": server_spec})["server"]
 
     def _check_server_specs_are_equal(
         self, first_server_spec, second_server_spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "openhands-sdk==1.31.0",
-  "openhands-tools==1.31.0",
+  "openhands-sdk==1.41.0",
+  "openhands-tools==1.41.0",
   "openhands-workspace==1.11.1",
   "rich<14.3.0",
   "textual>=8.0.0,<9.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,13 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "openhands-sdk==1.28.1",
-  "openhands-tools==1.28.1",
+  "openhands-sdk==1.31.0",
+  "openhands-tools==1.31.0",
   "openhands-workspace==1.11.1",
   "rich<14.3.0",
   "textual>=8.0.0,<9.0.0",
   "typer>=0.17.4",
-  "agent-client-protocol>=0.8.1,<0.9.0",
+  "agent-client-protocol>=0.10.1,<0.11.0",
   "pydantic>=2.7",
   "textual-autocomplete>=4.0.6",
   "pyperclip>=1.9.0",

--- a/tests/acp/test_confirmation.py
+++ b/tests/acp/test_confirmation.py
@@ -8,7 +8,7 @@ from acp.schema import (
     CreateTerminalResponse,
     DeniedOutcome,
     EnvVariable,
-    KillTerminalCommandResponse,
+    KillTerminalResponse,
     PermissionOption,
     ReadTextFileResponse,
     ReleaseTerminalResponse,
@@ -122,7 +122,7 @@ class MockACPConnection:
 
     async def kill_terminal(
         self, session_id: str, terminal_id: str, **kwargs: Any
-    ) -> KillTerminalCommandResponse | None:
+    ) -> KillTerminalResponse | None:
         """Stub method."""
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,9 @@ def save_test_agent(
         model: LLM model identifier (default: openai/gpt-4o-mini)
         api_key: Mock API key (default: test-key)
         tools: List of tools (default: empty list)
-        mcp_config: MCP configuration dict (default: empty dict)
+        mcp_config: MCP configuration dict (default: empty dict).
+            Passed to Agent.mcp_config which expects the flat
+            ``{name: server_spec}`` format (openhands-sdk >= 1.32).
 
     Returns:
         The created Agent instance

--- a/tests/settings/test_mcp_settings_reconciliation.py
+++ b/tests/settings/test_mcp_settings_reconciliation.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from openhands_cli.locations import MCP_CONFIG_FILE
+from openhands_cli.locations import AGENT_SETTINGS_PATH, MCP_CONFIG_FILE
 from openhands_cli.stores import AgentStore
 from tests.conftest import MockLocations, save_test_agent
 
@@ -45,9 +45,7 @@ def test_load_overrides_persisted_mcp_with_mcp_json_file(
     save_test_agent(
         persistence_dir,
         mcp_config={
-            "mcpServers": {
-                "persistent_server": {"command": "python", "args": ["-m", "old_server"]}
-            }
+            "persistent_server": {"command": "python", "args": ["-m", "old_server"]}
         },
     )
 
@@ -64,14 +62,112 @@ def test_load_overrides_persisted_mcp_with_mcp_json_file(
     loaded = agent_store.load_or_create()
     assert loaded is not None
     # Expect ONLY the MCP json file's config
-    assert "mcpServers" in loaded.mcp_config
-    assert "file_server" in loaded.mcp_config["mcpServers"]
+    assert "file_server" in loaded.mcp_config
 
     # Check server properties
-    file_server = loaded.mcp_config["mcpServers"]["file_server"]
+    file_server = loaded.mcp_config["file_server"]
     assert file_server.command == "uvx"
     assert file_server.args == ["mcp-server-fetch"]
     assert file_server.transport == "stdio"
+
+
+@patch("openhands_cli.stores.agent_store.get_default_cli_tools", return_value=[])
+@patch("openhands_cli.stores.agent_store.get_llm_metadata", return_value={})
+def test_load_legacy_persisted_mcp_wrapper(
+    mock_meta, mock_tools, persistence_dir, agent_store
+):
+    """A persisted agent with the pre-1.32 {"mcpServers": ...} wrapper loads.
+
+    openhands-sdk >= 1.32 expects mcp_config as dict[str, MCPServer]. Agents
+    saved by older CLI versions used the wrapped format, which is coerced to
+    the flat format at load. mcp.json remains the single source of truth for
+    MCP servers (applied by load_or_create).
+    """
+    agent = save_test_agent(persistence_dir, mcp_config={})
+    data = json.loads(agent.model_dump_json(context={"expose_secrets": True}))
+    data["mcp_config"] = {
+        "mcpServers": {
+            "legacy_server": {"command": "python", "args": ["-m", "old_server"]}
+        }
+    }
+    (persistence_dir / AGENT_SETTINGS_PATH).write_text(json.dumps(data))
+
+    # load_from_disk must NOT report the legacy wrapper as corrupted; the
+    # persisted MCP config is coerced to the flat format.
+    loaded = agent_store.load_from_disk()
+    assert loaded is not None
+    assert set(loaded.mcp_config) == {"legacy_server"}
+    assert loaded.mcp_config["legacy_server"].command == "python"
+    assert loaded.llm.model == "openai/gpt-4o-mini"
+
+    # load_or_create applies runtime config (mcp.json), but must NOT report
+    # the legacy agent file as corrupted.
+    loaded_or_created = agent_store.load_or_create()
+    assert loaded_or_created is not None
+
+
+@patch("openhands_cli.stores.agent_store.get_default_cli_tools", return_value=[])
+@patch("openhands_cli.stores.agent_store.get_llm_metadata", return_value={})
+def test_load_persisted_mcp_with_fastmcp_string_auth(
+    mock_meta, mock_tools, persistence_dir, agent_store
+):
+    """Persisted fastmcp-style string auth is coerced to an SDK credential.
+
+    fastmcp's RemoteMCPServer accepts ``auth`` as a plain string ("oauth" or a
+    bearer token); the SDK models auth as a discriminated credential union.
+    """
+    agent = save_test_agent(persistence_dir, mcp_config={})
+    data = json.loads(agent.model_dump_json(context={"expose_secrets": True}))
+    data["mcp_config"] = {
+        "mcpServers": {
+            "oauth_server": {"url": "https://mcp.example.com", "auth": "oauth"},
+            "token_server": {"url": "https://api.example.com", "auth": "tok123"},
+        }
+    }
+    (persistence_dir / AGENT_SETTINGS_PATH).write_text(json.dumps(data))
+
+    loaded = agent_store.load_from_disk()
+    assert loaded is not None
+    assert loaded.mcp_config["oauth_server"].auth.strategy == "oauth2"
+    token_auth = loaded.mcp_config["token_server"].auth
+    assert token_auth.strategy == "bearer"
+    assert token_auth.value.get_secret_value() == "tok123"
+
+
+@patch("openhands_cli.stores.agent_store.get_default_cli_tools", return_value=[])
+@patch("openhands_cli.stores.agent_store.get_llm_metadata", return_value={})
+def test_load_uncoercible_persisted_mcp_is_dropped(
+    mock_meta, mock_tools, persistence_dir, agent_store
+):
+    """An uncoercible persisted mcp_config is dropped, not reported corrupted."""
+    agent = save_test_agent(persistence_dir, mcp_config={})
+    data = json.loads(agent.model_dump_json(context={"expose_secrets": True}))
+    data["mcp_config"] = {"broken_server": {"transport": "stdio"}}  # no command
+    (persistence_dir / AGENT_SETTINGS_PATH).write_text(json.dumps(data))
+
+    loaded = agent_store.load_from_disk()
+    assert loaded is not None
+    assert loaded.mcp_config == {}
+    assert loaded.llm.model == "openai/gpt-4o-mini"
+
+
+@patch("openhands_cli.stores.agent_store.get_default_cli_tools", return_value=[])
+@patch("openhands_cli.stores.agent_store.get_llm_metadata", return_value={})
+def test_load_non_mcp_validation_error_reports_corrupted(
+    mock_meta, mock_tools, persistence_dir, agent_store
+):
+    """A schema error unrelated to mcp_config is still reported as corrupted.
+
+    The persisted MCP value is dropped unconditionally at load, but other
+    broken fields (e.g. tools) must still surface as a corrupted file.
+    """
+    agent = save_test_agent(persistence_dir, mcp_config={})
+    data = json.loads(agent.model_dump_json(context={"expose_secrets": True}))
+    data["tools"] = "not-a-list"  # invalid: tools must be a list
+    (persistence_dir / AGENT_SETTINGS_PATH).write_text(json.dumps(data))
+
+    loaded = agent_store.load_from_disk()
+    assert loaded is None
 
 
 @patch("openhands_cli.stores.agent_store.get_default_cli_tools", return_value=[])
@@ -84,9 +180,7 @@ def test_load_when_mcp_file_missing_ignores_persisted_mcp(
     save_test_agent(
         persistence_dir,
         mcp_config={
-            "mcpServers": {
-                "persistent_server": {"command": "python", "args": ["-m", "old_server"]}
-            }
+            "persistent_server": {"command": "python", "args": ["-m", "old_server"]}
         },
     )
 
@@ -131,13 +225,13 @@ def test_load_mcp_configuration_filters_disabled_servers(
     assert loaded is not None
 
     # Should only load enabled servers (enabled_server and default_enabled_server)
-    assert "enabled_server" in loaded.mcp_config["mcpServers"]
-    assert "default_enabled_server" in loaded.mcp_config["mcpServers"]
-    assert "disabled_server" not in loaded.mcp_config["mcpServers"]
+    assert "enabled_server" in loaded.mcp_config
+    assert "default_enabled_server" in loaded.mcp_config
+    assert "disabled_server" not in loaded.mcp_config
 
     # Verify the loaded servers have correct properties
-    assert loaded.mcp_config["mcpServers"]["enabled_server"].command == "uvx"
-    default_enabled = loaded.mcp_config["mcpServers"]["default_enabled_server"]
+    assert loaded.mcp_config["enabled_server"].command == "uvx"
+    default_enabled = loaded.mcp_config["default_enabled_server"]
     assert default_enabled.command == "node"
 
 

--- a/tests/snapshots/test_app_snapshots.py
+++ b/tests/snapshots/test_app_snapshots.py
@@ -18,11 +18,12 @@ import importlib.resources as resources
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
-from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
+from pydantic import SecretStr
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import Footer, Static
 
+from openhands.sdk.mcp.config import MCPOAuthAuthCredential, MCPServer
 from openhands.tools.task_tracker.definition import TaskItem
 from openhands_cli.theme import OPENHANDS_THEME
 from openhands_cli.tui.modals.exit_modal import ExitConfirmationModal
@@ -40,7 +41,7 @@ if TYPE_CHECKING:
 def _create_mock_agent(mcp_config: dict[str, Any] | None = None) -> Any:
     """Create a mock Agent with MCP configuration."""
     mock_agent = MagicMock()
-    mock_agent.mcp_config = mcp_config or {"mcpServers": {}}
+    mock_agent.mcp_config = mcp_config or {}
     return mock_agent
 
 
@@ -216,7 +217,7 @@ class TestMCPSidePanelSnapshots:
 
     def test_mcp_panel_empty_state(self, snap_compare):
         """Snapshot test for MCP panel with no servers configured."""
-        mock_agent = _create_mock_agent({"mcpServers": {}})
+        mock_agent = _create_mock_agent({})
 
         class MCPPanelEmptyApp(App):
             CSS = """
@@ -245,24 +246,22 @@ class TestMCPSidePanelSnapshots:
         assert snap_compare(MCPPanelEmptyApp(agent=mock_agent), terminal_size=(100, 30))
 
     def test_mcp_panel_with_remote_servers(self, snap_compare):
-        """Snapshot test for MCP panel with RemoteMCPServer objects.
+        """Snapshot test for MCP panel with MCPServer objects.
 
-        This test verifies the fix for issue #362 where RemoteMCPServer
+        This test verifies the fix for issue #362 where MCPServer
         objects caused a crash when opening the MCP menu.
         """
         mcp_config = {
-            "mcpServers": {
-                "notion": RemoteMCPServer(
-                    url="https://mcp.notion.com/mcp",
-                    transport="http",
-                    auth="oauth",
-                ),
-                "api_server": RemoteMCPServer(
-                    url="https://api.example.com/mcp",
-                    transport="http",
-                    headers={"Authorization": "Bearer token"},
-                ),
-            }
+            "notion": MCPServer(
+                url="https://mcp.notion.com/mcp",
+                transport="http",
+                auth=MCPOAuthAuthCredential(strategy="oauth2"),
+            ),
+            "api_server": MCPServer(
+                url="https://api.example.com/mcp",
+                transport="http",
+                headers={"Authorization": SecretStr("Bearer token")},
+            ),
         }
         mock_agent = _create_mock_agent(mcp_config)
 
@@ -295,16 +294,14 @@ class TestMCPSidePanelSnapshots:
         )
 
     def test_mcp_panel_with_stdio_servers(self, snap_compare):
-        """Snapshot test for MCP panel with StdioMCPServer objects."""
+        """Snapshot test for MCP panel with stdio MCPServer objects."""
         mcp_config = {
-            "mcpServers": {
-                "local_server": StdioMCPServer(
-                    command="python",
-                    args=["-m", "mcp_server"],
-                    transport="stdio",
-                    env={"API_KEY": "secret"},
-                ),
-            }
+            "local_server": MCPServer(
+                command="python",
+                args=["-m", "mcp_server"],
+                transport="stdio",
+                env={"API_KEY": SecretStr("secret")},
+            ),
         }
         mock_agent = _create_mock_agent(mcp_config)
 
@@ -339,18 +336,16 @@ class TestMCPSidePanelSnapshots:
     def test_mcp_panel_with_mixed_servers(self, snap_compare):
         """Snapshot test for MCP panel with both remote and stdio servers."""
         mcp_config = {
-            "mcpServers": {
-                "notion": RemoteMCPServer(
-                    url="https://mcp.notion.com/mcp",
-                    transport="http",
-                    auth="oauth",
-                ),
-                "local_tool": StdioMCPServer(
-                    command="npx",
-                    args=["@modelcontextprotocol/server-filesystem"],
-                    transport="stdio",
-                ),
-            }
+            "notion": MCPServer(
+                url="https://mcp.notion.com/mcp",
+                transport="http",
+                auth=MCPOAuthAuthCredential(strategy="oauth2"),
+            ),
+            "local_tool": MCPServer(
+                command="npx",
+                args=["@modelcontextprotocol/server-filesystem"],
+                transport="stdio",
+            ),
         }
         mock_agent = _create_mock_agent(mcp_config)
 

--- a/tests/test_agent_context_os_info.py
+++ b/tests/test_agent_context_os_info.py
@@ -15,7 +15,7 @@ def test_agent_context_includes_os_info() -> None:
             "openhands_cli.stores.agent_store.get_os_description",
             return_value="TestOS 1.0",
         ),
-        patch("openhands_cli.stores.agent_store.list_enabled_servers", return_value=[]),
+        patch("openhands_cli.stores.agent_store.list_enabled_servers", return_value={}),
     ):
         mock_store_instance = MagicMock()
         mock_file_store.return_value = mock_store_instance

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,10 +5,11 @@ from argparse import Namespace
 from unittest.mock import patch
 
 import pytest
-from acp.schema import EnvVariable, McpServerStdio
+from acp.schema import EnvVariable, HttpHeader, HttpMcpServer, McpServerStdio
 
 from openhands.sdk.event import MessageEvent, SystemPromptEvent
 from openhands.sdk.llm import Message, TextContent
+from openhands.sdk.mcp.config import MCPServer
 from openhands_cli.acp_impl.utils import convert_acp_mcp_servers_to_agent_format
 from openhands_cli.deprecated_utils import conversation_has_delegate_tool
 from openhands_cli.utils import (
@@ -157,6 +158,54 @@ def test_convert_acp_mcp_servers_multiple_servers():
     assert "server2" in result
     assert result["server1"]["env"] == {}
     assert result["server2"]["env"] == {"KEY": "value"}
+
+
+def test_convert_acp_mcp_servers_stdio_validates_as_sdk_mcp_server():
+    """Converted stdio specs must validate against the SDK's MCPServer model.
+
+    ACP schema dumps include metadata fields (e.g. field_meta) that the SDK
+    model forbids; setup.py validates these dicts with MCPServer.
+    """
+    servers = [
+        McpServerStdio(
+            name="local",
+            command="/usr/bin/npx",
+            args=["-y", "srv"],
+            env=[EnvVariable(name="A", value="1")],
+        )
+    ]
+    result = convert_acp_mcp_servers_to_agent_format(servers)
+
+    validated = MCPServer.model_validate(result["local"])
+    assert validated.command == "/usr/bin/npx"
+    assert validated.transport == "stdio"
+    assert validated.env is not None
+    assert validated.env["A"].get_secret_value() == "1"
+
+
+def test_convert_acp_mcp_servers_http_headers_validate_as_sdk_mcp_server():
+    """ACP HTTP server headers convert from EnvVariable array to dict.
+
+    Regression test: the SDK's MCPServer requires headers as a dict and
+    forbids ACP metadata extras (field_meta, type).
+    """
+    servers = [
+        HttpMcpServer(
+            type="http",
+            name="remote",
+            url="https://mcp.example.com/mcp",
+            headers=[HttpHeader(name="Authorization", value="Bearer tok")],
+        )
+    ]
+    result = convert_acp_mcp_servers_to_agent_format(servers)
+
+    assert result["remote"]["headers"] == {"Authorization": "Bearer tok"}
+    assert result["remote"]["transport"] == "http"
+
+    validated = MCPServer.model_validate(result["remote"])
+    assert validated.url == "https://mcp.example.com/mcp"
+    assert validated.headers is not None
+    assert validated.headers["Authorization"].get_secret_value() == "Bearer tok"
 
 
 def test_seeded_instructions_task_only():

--- a/tests/tui/panels/test_mcp_side_panel.py
+++ b/tests/tui/panels/test_mcp_side_panel.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import Static
 
+from openhands.sdk.mcp.config import MCPOAuthAuthCredential, MCPServer
+from openhands_cli.stores.agent_store import convert_mcp_servers
 from openhands_cli.tui.panels.mcp_side_panel import MCPSidePanel
 from tests.conftest import MockLocations
 
@@ -23,7 +24,7 @@ if TYPE_CHECKING:
 def _create_mock_agent(mcp_config: dict[str, Any] | None = None) -> Any:
     """Create a mock Agent with MCP configuration."""
     mock_agent = MagicMock()
-    mock_agent.mcp_config = mcp_config or {"mcpServers": {}}
+    mock_agent.mcp_config = mcp_config or {}
     return mock_agent
 
 
@@ -57,116 +58,66 @@ class MCPPanelTestApp(App):
 class TestCheckServerSpecsAreEqual:
     """Tests for MCPSidePanel._check_server_specs_are_equal method."""
 
-    def test_equal_dict_specs(self):
-        """Verify equal dict specs return True."""
-        mock_agent = _create_mock_agent()
-        panel = MCPSidePanel(agent=mock_agent)
+    def test_equal_mcp_server_objects(self):
+        """Verify equal MCPServer specs return True."""
+        panel = MCPSidePanel(agent=_create_mock_agent())
 
-        spec1 = {"url": "https://example.com", "transport": "http"}
-        spec2 = {"url": "https://example.com", "transport": "http"}
+        spec1 = MCPServer(url="https://example.com", transport="http")
+        spec2 = MCPServer(url="https://example.com", transport="http")
 
-        result = panel._check_server_specs_are_equal(spec1, spec2)
-        assert result is True
+        assert panel._check_server_specs_are_equal(spec1, spec2) is True
 
-    def test_different_dict_specs(self):
-        """Verify different dict specs return False."""
-        mock_agent = _create_mock_agent()
-        panel = MCPSidePanel(agent=mock_agent)
+    def test_different_mcp_server_objects(self):
+        """Verify different MCPServer specs return False."""
+        panel = MCPSidePanel(agent=_create_mock_agent())
 
-        spec1 = {"url": "https://example.com", "transport": "http"}
-        spec2 = {"url": "https://other.com", "transport": "http"}
+        spec1 = MCPServer(url="https://example.com", transport="http")
+        spec2 = MCPServer(url="https://other.com", transport="http")
 
-        result = panel._check_server_specs_are_equal(spec1, spec2)
-        assert result is False
+        assert panel._check_server_specs_are_equal(spec1, spec2) is False
 
-    def test_remote_mcp_server_objects_are_serializable(self):
-        """Test that RemoteMCPServer objects can be compared without JSON error.
+    def test_mcp_server_object_vs_raw_dict(self):
+        """Compare an MCPServer (current) with a raw mcp.json dict (incoming).
 
-        This test reproduces the bug from issue #362 where RemoteMCPServer
-        objects caused TypeError: Object of type RemoteMCPServer is not JSON
-        serializable.
+        This is the shape of the "Incoming on Restart" comparison: the
+        persisted agent holds MCPServer objects while get_config_status()
+        returns raw dicts. Equal configurations must compare equal.
         """
-        mock_agent = _create_mock_agent()
-        panel = MCPSidePanel(agent=mock_agent)
+        panel = MCPSidePanel(agent=_create_mock_agent())
 
-        # Create RemoteMCPServer objects (as they would be in agent.mcp_config)
-        server1 = RemoteMCPServer(
-            url="https://api.example.com",
-            transport="http",
-            headers={"Authorization": "Bearer token"},
-        )
-        server2 = RemoteMCPServer(
-            url="https://api.example.com",
-            transport="http",
-            headers={"Authorization": "Bearer token"},
-        )
+        current = MCPServer(url="https://api.example.com", transport="http")
+        incoming = {"url": "https://api.example.com", "transport": "http"}
 
-        # This should NOT raise TypeError
-        result = panel._check_server_specs_are_equal(server1, server2)
-        assert result is True
+        assert panel._check_server_specs_are_equal(current, incoming) is True
 
-    def test_stdio_mcp_server_objects_are_serializable(self):
-        """Test that StdioMCPServer objects can be compared without JSON error."""
-        mock_agent = _create_mock_agent()
-        panel = MCPSidePanel(agent=mock_agent)
+    def test_mcp_server_object_vs_changed_raw_dict(self):
+        """A modified incoming dict must compare unequal."""
+        panel = MCPSidePanel(agent=_create_mock_agent())
 
-        # Create StdioMCPServer objects
-        server1 = StdioMCPServer(
-            command="python",
-            args=["-m", "server"],
-            transport="stdio",
-            env={"API_KEY": "secret"},
-        )
-        server2 = StdioMCPServer(
-            command="python",
-            args=["-m", "server"],
-            transport="stdio",
-            env={"API_KEY": "secret"},
-        )
+        current = MCPServer(url="https://api.example.com", transport="http")
+        incoming = {"url": "https://api.example.com", "transport": "sse"}
 
-        # This should NOT raise TypeError
-        result = panel._check_server_specs_are_equal(server1, server2)
-        assert result is True
+        assert panel._check_server_specs_are_equal(current, incoming) is False
 
-    def test_mixed_server_and_dict_comparison(self):
-        """Test comparing a server object with a dict representation."""
-        mock_agent = _create_mock_agent()
-        panel = MCPSidePanel(agent=mock_agent)
+    def test_mcp_server_with_string_auth_vs_raw_dict(self):
+        """fastmcp-style string auth in mcp.json matches the coerced current."""
+        panel = MCPSidePanel(agent=_create_mock_agent())
 
-        # RemoteMCPServer object (from agent.mcp_config)
-        server_obj = RemoteMCPServer(
-            url="https://api.example.com",
-            transport="http",
-        )
+        current = convert_mcp_servers(
+            {"s": {"url": "https://mcp.notion.com/mcp", "auth": "oauth"}}
+        )["s"]
+        incoming = {"url": "https://mcp.notion.com/mcp", "auth": "oauth"}
 
-        # Dict representation (from get_config_status)
-        server_dict = {
-            "url": "https://api.example.com",
-            "transport": "http",
-        }
+        assert panel._check_server_specs_are_equal(current, incoming) is True
 
-        # This should NOT raise TypeError
-        result = panel._check_server_specs_are_equal(server_obj, server_dict)
-        # The result may be True or False depending on implementation,
-        # but it should not raise an exception
-        assert isinstance(result, bool)
+    def test_uncoercible_incoming_dict_does_not_raise(self):
+        """An invalid incoming spec is reported as changed, not an error."""
+        panel = MCPSidePanel(agent=_create_mock_agent())
 
-    def test_different_remote_mcp_servers(self):
-        """Test that different RemoteMCPServer objects return False."""
-        mock_agent = _create_mock_agent()
-        panel = MCPSidePanel(agent=mock_agent)
+        current = MCPServer(url="https://api.example.com", transport="http")
+        incoming = {"transport": "stdio"}  # missing required command
 
-        server1 = RemoteMCPServer(
-            url="https://api.example.com",
-            transport="http",
-        )
-        server2 = RemoteMCPServer(
-            url="https://other.example.com",
-            transport="http",
-        )
-
-        result = panel._check_server_specs_are_equal(server1, server2)
-        assert result is False
+        assert panel._check_server_specs_are_equal(current, incoming) is False
 
 
 # ============================================================================
@@ -198,14 +149,12 @@ class TestRefreshContentWithServerObjects:
         mcp_config_file = mock_locations.persistence_dir / "mcp.json"
         mcp_config_file.write_text(json.dumps(mcp_config_data))
 
-        # Create agent with RemoteMCPServer objects (as they would be loaded)
+        # Create agent with MCPServer objects (as they would be loaded from mcp.json)
         agent_mcp_config = {
-            "mcpServers": {
-                "test_server": RemoteMCPServer(
-                    url="https://api.example.com",
-                    transport="http",
-                )
-            }
+            "test_server": MCPServer(
+                url="https://api.example.com",
+                transport="http",
+            )
         }
         mock_agent = _create_mock_agent(agent_mcp_config)
 
@@ -257,18 +206,16 @@ class TestRefreshContentWithServerObjects:
         mcp_config_file = mock_locations.persistence_dir / "mcp.json"
         mcp_config_file.write_text(json.dumps(mcp_config_data))
 
-        # Create agent with RemoteMCPServer objects
+        # Create agent with MCPServer objects
         agent_mcp_config = {
-            "mcpServers": {
-                "enabled_server": RemoteMCPServer(
-                    url="https://enabled.example.com",
-                    transport="http",
-                ),
-                "disabled_server": RemoteMCPServer(
-                    url="https://disabled.example.com",
-                    transport="http",
-                ),
-            }
+            "enabled_server": MCPServer(
+                url="https://enabled.example.com",
+                transport="http",
+            ),
+            "disabled_server": MCPServer(
+                url="https://disabled.example.com",
+                transport="http",
+            ),
         }
         mock_agent = _create_mock_agent(agent_mcp_config)
 
@@ -293,6 +240,87 @@ class TestRefreshContentWithServerObjects:
 
             # This should NOT raise TypeError
             panel.refresh_content()
+
+
+# ============================================================================
+# Incoming on Restart section Tests
+# ============================================================================
+
+
+class TestIncomingOnRestart:
+    """Tests for the Incoming on Restart section of refresh_content."""
+
+    @pytest.mark.asyncio
+    async def test_incoming_section_shows_new_and_updated(
+        self, mock_locations: MockLocations
+    ):
+        """New and changed mcp.json servers are listed for the next restart."""
+        mcp_config_data = {
+            "mcpServers": {
+                "unchanged": {"url": "https://same.example.com", "transport": "http"},
+                "updated": {"url": "https://new-url.example.com", "transport": "http"},
+                "brand_new": {"command": "npx", "args": ["-y", "srv"]},
+            }
+        }
+        mcp_config_file = mock_locations.persistence_dir / "mcp.json"
+        mcp_config_file.write_text(json.dumps(mcp_config_data))
+
+        mock_agent = _create_mock_agent(
+            {
+                "unchanged": MCPServer(
+                    url="https://same.example.com", transport="http"
+                ),
+                "updated": MCPServer(
+                    url="https://old-url.example.com", transport="http"
+                ),
+            }
+        )
+
+        app = MCPPanelTestApp()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            panel = MCPSidePanel(agent=mock_agent)
+            content_area = app.query_one("#content_area", Horizontal)
+            content_area.mount(panel)
+            await pilot.pause()
+
+            content = str(app.query_one("#mcp-content", Static).content)
+            assert "Incoming on Restart:" in content
+            assert "New:" in content
+            assert "brand_new" in content
+            assert "Updated:" in content
+            assert "updated" in content
+
+    @pytest.mark.asyncio
+    async def test_incoming_section_all_match(self, mock_locations: MockLocations):
+        """Identical mcp.json servers report as matching current."""
+        mcp_config_data = {
+            "mcpServers": {
+                "same": {"url": "https://same.example.com", "transport": "http"},
+            }
+        }
+        mcp_config_file = mock_locations.persistence_dir / "mcp.json"
+        mcp_config_file.write_text(json.dumps(mcp_config_data))
+
+        mock_agent = _create_mock_agent(
+            {"same": MCPServer(url="https://same.example.com", transport="http")}
+        )
+
+        app = MCPPanelTestApp()
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            panel = MCPSidePanel(agent=mock_agent)
+            content_area = app.query_one("#content_area", Horizontal)
+            content_area.mount(panel)
+            await pilot.pause()
+
+            content = str(app.query_one("#mcp-content", Static).content)
+            assert "Incoming on Restart:" in content
+            assert "All servers match current" in content
 
 
 # ============================================================================
@@ -360,15 +388,13 @@ class TestToggle:
         mcp_config_file = mock_locations.persistence_dir / "mcp.json"
         mcp_config_file.write_text(json.dumps(mcp_config_data))
 
-        # Create agent settings with RemoteMCPServer objects
+        # Create agent settings with MCPServer objects
         agent_mcp_config = {
-            "mcpServers": {
-                "notion": RemoteMCPServer(
-                    url="https://mcp.notion.com/mcp",
-                    transport="http",
-                    auth="oauth",
-                )
-            }
+            "notion": MCPServer(
+                url="https://mcp.notion.com/mcp",
+                transport="http",
+                auth=MCPOAuthAuthCredential(strategy="oauth2"),
+            )
         }
 
         # Create a mock agent that will be returned by AgentStore.load()
@@ -378,7 +404,7 @@ class TestToggle:
 
         with patch("openhands_cli.stores.AgentStore") as mock_agent_store_class:
             mock_agent_store = MagicMock()
-            mock_agent_store.load.return_value = mock_agent
+            mock_agent_store.load_from_disk.return_value = mock_agent
             mock_agent_store_class.return_value = mock_agent_store
 
             async with app.run_test() as pilot:

--- a/uv.lock
+++ b/uv.lock
@@ -12,14 +12,14 @@ openhands-sdk = false
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.8.1"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7b/7cdac86db388809d9e3bc58cac88cc7dfa49b7615b98fab304a828cd7f8a/agent_client_protocol-0.8.1.tar.gz", hash = "sha256:1bbf15663bf51f64942597f638e32a6284c5da918055d9672d3510e965143dbd", size = 68866, upload-time = "2026-02-13T15:34:54.567Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/a0/3b96cd8374725c69bc3dae9fcc2082f3f6cafec1be35d24d7af0f8c3265f/agent_client_protocol-0.10.1.tar.gz", hash = "sha256:355c65ca19f0568344aafc2c1552b7066a8fc491df23ab28e7e253c6c9a85a25", size = 81924, upload-time = "2026-05-24T18:46:44.444Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/f3/219eeca0ad4a20843d4b9eaac5532f87018b9d25730a62a16f54f6c52d1a/agent_client_protocol-0.8.1-py3-none-any.whl", hash = "sha256:9421a11fd435b4831660272d169c3812d553bb7247049c138c3ca127e4b8af8e", size = 54529, upload-time = "2026-02-13T15:34:53.344Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/18/d8c7ff337cf621ea79a84006a7252ff057bfb5767549bb102cc6649f4ec2/agent_client_protocol-0.10.1-py3-none-any.whl", hash = "sha256:a03d3198f4d772f2e0ec012c00ac1cce131b4710220a3dc9fae3c991d047c750", size = 65401, upload-time = "2026-05-24T18:46:43.202Z" },
 ]
 
 [[package]]
@@ -1748,10 +1748,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", specifier = ">=0.8.1,<0.9.0" },
+    { name = "agent-client-protocol", specifier = ">=0.10.1,<0.11.0" },
     { name = "httpx", specifier = ">=0.25.0" },
-    { name = "openhands-sdk", specifier = "==1.28.1" },
-    { name = "openhands-tools", specifier = "==1.28.1" },
+    { name = "openhands-sdk", specifier = "==1.31.0" },
+    { name = "openhands-tools", specifier = "==1.31.0" },
     { name = "openhands-workspace", specifier = "==1.11.1" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyperclip", specifier = ">=1.9.0" },
@@ -1808,7 +1808,7 @@ wheels = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.28.1"
+version = "1.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1829,14 +1829,14 @@ dependencies = [
     { name = "tree-sitter-bash" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/12/962f84a1576d5a68d4c5bdf13c573de18ecc36ec88e20dc69fef5730da95/openhands_sdk-1.28.1.tar.gz", hash = "sha256:249148599c124fa1b3221b2b47207cb6982203d0bb4f5f4fec8f55f026e7e4ce", size = 536814, upload-time = "2026-06-11T18:35:14.371Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/1e/f73c96c83576eb35eae11d5c9f186a8101a238496addc260b998a22647a5/openhands_sdk-1.31.0.tar.gz", hash = "sha256:a076bd08f0242ae306dcd76a19b402c9da8fb5a45faf05dc6c9118e52708383b", size = 598904, upload-time = "2026-07-02T18:58:27.103Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/73/d3c0e0598fa5f52e984c81a852405d5bacd2e8f588e66715f705311b37c4/openhands_sdk-1.28.1-py3-none-any.whl", hash = "sha256:fce1ff4fed0a661e66d2621a489c092c67458d203ccc5a91636653c61af7f209", size = 649537, upload-time = "2026-06-11T18:35:16.67Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/37/789050577860e30e8a4808bdfd8d8c8215a866564161853eb8c97b9df60c/openhands_sdk-1.31.0-py3-none-any.whl", hash = "sha256:fe690ce1c9ab14e1b505dd42f9f6504b3fa89cbf23cb7267a871e1c26f718085", size = 720101, upload-time = "2026-07-02T18:58:21.639Z" },
 ]
 
 [[package]]
 name = "openhands-tools"
-version = "1.28.1"
+version = "1.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "binaryornot" },
@@ -1850,9 +1850,9 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-bash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/25/0507f0d99d87d3605395772c0e0c2d73adeeb5c0a3c9319559257582adef/openhands_tools-1.28.1.tar.gz", hash = "sha256:47667fec9b981da57a64cb1ce3d93b1e3405d2a5f408c3741668240901a72507", size = 142489, upload-time = "2026-06-11T18:35:15.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/b4/00234765d2fe88e08f5df545e81b4689846b2d9bb56b779ac90dc1e9ddc3/openhands_tools-1.31.0.tar.gz", hash = "sha256:33ce3a4109685c91c00a6b28f543b2dffa6316c71ba542b2c63086553eea65f9", size = 145885, upload-time = "2026-07-02T18:58:28.195Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/aa/ed7c2b9874504d638260d36e63cdd6a1da5148b3459c6326fd651b9bab63/openhands_tools-1.28.1-py3-none-any.whl", hash = "sha256:9ebee79b05e20321f3f7518bf5eb74aa85cf39f0b43a63c5895c57d0a1da2dc0", size = 187637, upload-time = "2026-06-11T18:35:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e6/83de568fa4aecd8dd78d943a76e1a936faad7d780b82d56e22de68304fbb/openhands_tools-1.31.0-py3-none-any.whl", hash = "sha256:b1fe85efae5072f9bcf21f2b6147ca5f458ad7cb71e5c8467311126ee7d3f54e", size = 191219, upload-time = "2026-07-02T18:58:23.167Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -260,6 +260,27 @@ wheels = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/6a/4cc5a9dd40fd8a6d283fd3761e5f59c490109571ef8e3c73245417e5a305/blake3-1.0.9.tar.gz", hash = "sha256:5fa374fa5070ca084368776c19b420157eb0f2d3f091343d6bc59189929d62e2", size = 116872, upload-time = "2026-06-22T18:02:25.366Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/d2/9bdf8345c70993aaef635398f52edfb915d6e8ad2c000c801204e387c456/blake3-1.0.9-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a70c20542d5e7960983a0ff32999049a2b0e5ef1f22dbbbdfb51cf04828a4156", size = 344587, upload-time = "2026-06-22T18:00:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/36/9d/be8b1f7f85b12bb45a0fade6ca7bdbf83a507d23d0b6141ba29fe69c8cea/blake3-1.0.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:72cdecf088a9d25e6ec79948a578995649b0dbee407e7a46c543a9ecc0f6f281", size = 328864, upload-time = "2026-06-22T18:00:35.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/66580635d744c826671fd219938caffb16281a26f62c4f856695d4233677/blake3-1.0.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42fa57bf462285ef16400601b0fd32214c248ba92505bbb94b1221ab9af5a092", size = 373795, upload-time = "2026-06-22T18:00:36.887Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/79/b5b17d3004bb81a5732c0b176c812703d200ed8c652b3b7713b9633bbe10/blake3-1.0.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b25ccde5a64be070f20e5c7a81da70292db40b164b6c77588cbd6230856badbb", size = 374183, upload-time = "2026-06-22T18:00:38.205Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/63/0d209c44b2041bbe130ced12a23c92dd995fbfe5bce7ee77fffea16f5cb0/blake3-1.0.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a800b87433955f37691b5f361ad29c7dd3ee089c9cd109adc5aea8e24bc4c1f", size = 446783, upload-time = "2026-06-22T18:00:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/51/efd1f9b8a9d3e9a0e235f3ced99a738529a1019fe78b3988e29d9c2fbba6/blake3-1.0.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6879739e7904b9c42afbedbcc2e8c36cebe140fb3fc3f5c492993579cf5cd516", size = 487369, upload-time = "2026-06-22T18:00:40.875Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3f/a8dcaea9e0b26e419a540ca0cd6203c9fbb505e85b02b03c5a59bf9e6a45/blake3-1.0.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6edeb3d49a24c307995899b70dd47aa901d0e9ad51d2f8a79aba4f074f32d8c5", size = 383845, upload-time = "2026-06-22T18:00:42.251Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/10/e9907f5b86410d5071982aaf05d149ca4d4fd8acab7e77eebbc9a333c7b4/blake3-1.0.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcd56a7a972c4185070f7042ccc20166927eec3c0f98b8405f375d007b604a0b", size = 383851, upload-time = "2026-06-22T18:00:43.715Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/c7863a185550706a9624f6aa7b6d46470aaed0bb46a827c5cda2a7d03151/blake3-1.0.9-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:a288664d08dee154cc496e06e62517fc9e655ecec12b0d7db538d244ac79edf1", size = 380067, upload-time = "2026-06-22T18:00:45.249Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0a/e7af679c719368b400c9ba9c3460072aac2ba077ddbd4bc806fef28cda03/blake3-1.0.9-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:91db52a809b68b5bebe7c413ddcd230e1f759398e7fa7a873104595a4fa648b6", size = 549471, upload-time = "2026-06-22T18:00:46.793Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3c/37c1dd3539b7bd9b6d2eef019802aacdb4a3d48ab484b140603bbf9c5b5a/blake3-1.0.9-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cfaa671b07eb73883162ca940442193868358b0b904cfa266e4b74131ce966da", size = 591396, upload-time = "2026-06-22T18:00:48.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/55/4f0a23b72795292e74084834130900ea778c0583004519c86698dfffe1a5/blake3-1.0.9-cp312-cp312-win32.whl", hash = "sha256:ae47c3d5729ff89baa6ddf6de47fcfcc915985d39eb1bfcd6db653331f3c6fcc", size = 229271, upload-time = "2026-06-22T18:00:49.377Z" },
+    { url = "https://files.pythonhosted.org/packages/12/91/7db93e4689f0f145bcb954dc62936e5f5090548a9fa20c6bbebfaeaa648a/blake3-1.0.9-cp312-cp312-win_amd64.whl", hash = "sha256:15566065ff90ab3da46ec0be1417406f00507af902b6fb0fbc6563e77f02fc42", size = 218220, upload-time = "2026-06-22T18:00:50.659Z" },
+]
+
+[[package]]
 name = "browser-use"
 version = "0.11.13"
 source = { registry = "https://pypi.org/simple" }
@@ -1326,7 +1347,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.87.0"
+version = "1.93.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1342,16 +1363,18 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/0d/ccdf682ccfd7f18bf0e179c39d85616b8f8ef05a798588285310412db13d/litellm-1.87.0.tar.gz", hash = "sha256:cafc1882cb0cbab8374c41180af86e4a067796e4524e15f59e99f6e689cd1bd8", size = 15453755, upload-time = "2026-06-02T03:53:29.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/e1/4f05ca4cbb4efb739c9e66a182ecd5c816bc05bf3665ec8e0fb4ab408379/litellm-1.93.0.tar.gz", hash = "sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec", size = 15948866, upload-time = "2026-07-19T03:01:24.389Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/20/88a372fa7e50fc2c33458c6eef94a79afcf7bdfa43610079531b82b484a3/litellm-1.87.0-py3-none-any.whl", hash = "sha256:fbbba7e47ae29b55f878fe1acc80effb92761bc168f6236bd81a0cb6e147d855", size = 17103948, upload-time = "2026-06-02T03:53:25.677Z" },
+    { url = "https://files.pythonhosted.org/packages/be/69/cabe7e747fea4c744752bd7ff8f7f208723151a63a89bb7c2437212523ff/litellm-1.93.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3daf5c5aceb07f5d68871071e0ecdc678caccebadca9143cc00bb76f5a8c54e8", size = 20164234, upload-time = "2026-07-19T03:01:05.713Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/db/6af798603c6e2cf21ad7f2edf7e95019bd859dda82284b94014d608fcd85/litellm-1.93.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0784172435de48f66ef7ad89d421604db1ad0db1321ef7f39dbcfe6b20111417", size = 20156724, upload-time = "2026-07-19T03:01:09.037Z" },
 ]
 
 [[package]]
 name = "lmnr"
-version = "0.7.49"
+version = "0.7.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "blake3" },
     { name = "grpcio" },
     { name = "httpx" },
     { name = "lmnr-claude-code-proxy" },
@@ -1370,35 +1393,35 @@ dependencies = [
     { name = "tenacity" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/ba/6ea688579cde53791d0e855d0a5b42a0893b102951d34d73f3c7e75882d4/lmnr-0.7.49.tar.gz", hash = "sha256:0b6da7d1707ce4e248c15083835a70723be9e6cc652b77ddc95c12e27dc87ef3", size = 255416, upload-time = "2026-04-26T12:10:24.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/6665b4ba365db31d8b34799a0d5eacc7a4fb735da979dfaa37bcbfdf96f2/lmnr-0.7.56.tar.gz", hash = "sha256:ec9530f6cc5ddf1eaa3c0fa4dbb5a7a932e2be01b9fa739813f53607d834247b", size = 305842, upload-time = "2026-07-10T16:41:17.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/7b/7c3dfe9332a5f0d6ffcf924ac1ce2683f03ce6dae47a506b5460b9b38bea/lmnr-0.7.49-py3-none-any.whl", hash = "sha256:510113b02bac3e639fa80244c67ff0be5948234275b0ef04cd310d66c7d720bf", size = 335069, upload-time = "2026-04-26T12:10:21.512Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c1/6cb3f998bb21f3961064b2b91a962b009d29f96b3fe42dae4b5e83c5ca8f/lmnr-0.7.56-py3-none-any.whl", hash = "sha256:bd3a5cc1be5d73cc3b6131c707c6abe74f9c499f9b8d1c7a76f5b2ca0f85e2be", size = 392156, upload-time = "2026-07-10T16:41:16.28Z" },
 ]
 
 [[package]]
 name = "lmnr-claude-code-proxy"
-version = "0.1.21"
+version = "0.1.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/c8/697a70901c32022ff3270e5d39d09c60edc86f9b95b0371acbaba95faffa/lmnr_claude_code_proxy-0.1.21.tar.gz", hash = "sha256:897cb3c87a0a0f9c9d681f178416407202eec16575573589ab42a1a4241e9346", size = 61105, upload-time = "2026-04-22T16:20:17.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/e8/b3987e4e286052f4ccaf4408fe5404d14e4c0f65841118ccc5c97de60d77/lmnr_claude_code_proxy-0.1.23.tar.gz", hash = "sha256:6d8fa044c2f5774a6b70de9025a91c13c74361d4349ae528b4b4fcca48219a13", size = 60777, upload-time = "2026-06-17T22:02:48.132Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/4d/583e1574534aaeac7fc21e2ab5c8391c62744980eaf596593cf48d154d97/lmnr_claude_code_proxy-0.1.21-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6e5286020412aca3d8a9613cce9526b40099436a0f5afc4fe06cc8229f08c456", size = 1372699, upload-time = "2026-04-22T16:22:25.556Z" },
-    { url = "https://files.pythonhosted.org/packages/63/7d/2ecfad1e2ab8a61af79459c4ccd6af8988bc52a2910189af115d01f88969/lmnr_claude_code_proxy-0.1.21-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8921cc4d3a5cfc7f47f43b26790f70835ab94311ca03410aac4f10d41e1f3b04", size = 1313653, upload-time = "2026-04-22T16:21:02.605Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/a6cbed39e3438d6dfbe8e2b8ee5b6cfd5f61a0090cf7ad0369d6619278bb/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e855b3a52bd540c534abf8b87823855088bfb6068170dce43aea65b3b8d30642", size = 1358223, upload-time = "2026-04-22T16:20:18.195Z" },
-    { url = "https://files.pythonhosted.org/packages/53/55/18fb708d5daee9de8b439d8f7c419775b9ac9e88747a5b442ebac90c9964/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:815693c1e45aca834cd24b6a7e435d88d59a4dcd50bad2b55b1b89b179231c72", size = 1191660, upload-time = "2026-04-22T16:20:34.831Z" },
-    { url = "https://files.pythonhosted.org/packages/57/44/7f3df158b6421578b12a4c1c7d0b862d1c21f3364ab1e87c13a76a62b3a5/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:296432de34ff54543c702720215e5db4fdd2db97a2a84f9cb257c55b3a20f3c3", size = 1361646, upload-time = "2026-04-22T16:20:33.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/45/bcab851ddf317099def6c5ae7be52e758529a47bfddcbb81cd3abbd01aa5/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04455e30b8451d0b2f316ca6580806b65f3a246eafd8351fa5f8169f7800fa95", size = 1276576, upload-time = "2026-04-22T16:20:31.939Z" },
-    { url = "https://files.pythonhosted.org/packages/83/84/bc5799bc88f123ddd105edeabecfe247b2a967dadc6a158c0f406e89dee6/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64b245d6fcc97a851d23a3f66191076c6a729a599b9f597f59779beece6025a5", size = 1503868, upload-time = "2026-04-22T16:21:49.791Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/f6/8e7bed52697a7ac43ac71deff08c667b54df8e4ec654bde4bd805abfb245/lmnr_claude_code_proxy-0.1.21-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:39f181d84a00ee6bd6fe90fe3ce4b10e600ccd1a71a0ff26693defcb9fd9c6eb", size = 1471162, upload-time = "2026-04-22T16:22:47.643Z" },
-    { url = "https://files.pythonhosted.org/packages/58/f7/540674d61f2117fc2c4bcc8ac89d31a5334fd8e68a0032ffe6109e30ef83/lmnr_claude_code_proxy-0.1.21-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1a9b6dea12972f723536f1239976993ac74dd8a3e015c2b3c04a799422e6f6b4", size = 1646664, upload-time = "2026-04-22T16:20:03.48Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/b5/869f3d1effab5ace022a51206030d716dabda8f331abc2422f55449bc6ad/lmnr_claude_code_proxy-0.1.21-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:91e499ac1b45836541a6dcc13e433409ba6c97a6881677abbb42225769924167", size = 1466278, upload-time = "2026-04-22T16:21:04.047Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/c2/f3f0a36e1df6c8b1c9a093135b192985e0d172680da0a388074e8b7579f3/lmnr_claude_code_proxy-0.1.21-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:058a2cbf9be7c27cc98d155b6c01e5070834f3a748da89fdf0aaaf1878ca1a15", size = 1526212, upload-time = "2026-04-22T16:21:30.771Z" },
-    { url = "https://files.pythonhosted.org/packages/29/41/9c54ddc3e7670824477dcdca4468d8db7e2467f7bc76a98ddd8ee369a6a1/lmnr_claude_code_proxy-0.1.21-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a7035d9015ff03d42920c1d47a82cd182d256c3b80cac82f6d36cc5594983386", size = 1720244, upload-time = "2026-04-22T16:22:45.163Z" },
-    { url = "https://files.pythonhosted.org/packages/70/7b/b394ffc305084b7c16ed46211909ec17c34af6570286ccb4eec2e836fca0/lmnr_claude_code_proxy-0.1.21-cp312-cp312-win32.whl", hash = "sha256:0ec8296341ee28560623653cd9cbc9fe0cce213abbb7be1b76696a60cf8bc4d3", size = 1079244, upload-time = "2026-04-22T16:22:06.429Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ed/8d9d5dbfb84e505d3046b54ed79cbcd53adcb6ae79584f88f6c0604cca7d/lmnr_claude_code_proxy-0.1.21-cp312-cp312-win_amd64.whl", hash = "sha256:d29c00ce28af31855d7ba72a1a037c5f9f37148d2d08643f38a0e76cf195680e", size = 1323469, upload-time = "2026-04-22T16:20:07.286Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/32/66cab9f287768eeb28ebcad36f8d61d0b1ebe5dc200230c1af42956ba711/lmnr_claude_code_proxy-0.1.21-cp312-cp312-win_arm64.whl", hash = "sha256:da87d2da2b94057c69837fea8897878fbc564efc3740a9e7cd0faee9817786ff", size = 1239719, upload-time = "2026-04-22T16:21:45.134Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/56/a58d7d129b5d04de7086f168f6f8f38f140ec6bc57da11d9e0565612b136/lmnr_claude_code_proxy-0.1.23-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f05a1978c707ba5df0be531dd2cac0da8117c86c6172d84cb4f5180c8123fc49", size = 1372073, upload-time = "2026-06-17T22:04:43.739Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/de/58a11459ad5f4274b8e87c7c52386e3ed0e31806400a4c25bc418db2a7a2/lmnr_claude_code_proxy-0.1.23-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1304486204ddc39a3f5639153df6ae4ee53152ea83063b0ce3331360f05ee026", size = 1305975, upload-time = "2026-06-17T22:05:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/29ecaff001a7904bcc4f43c5eec537b8525816ec5f0ed4fac9122544478a/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a3769f25f3341ae04885f3b8668fd48214b8eb9b72faa97b9d7dbc9095c8a40d", size = 1355954, upload-time = "2026-06-17T22:02:45.19Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/c82f3b7e6672642bbfcab008294f324b979ec17fe8c4dd1caa2ac932011d/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c64fcdd623ceec9f41cf0cd6761409a1c0add4e85409de294faf0647f5eb86", size = 1189115, upload-time = "2026-06-17T22:04:10.61Z" },
+    { url = "https://files.pythonhosted.org/packages/09/84/6d49fdefdef24e37997cd9da6a7b3b1e0933fec7d6b9b357394e3a6bddcd/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c372c3678aa21d422644bef5955a68b4b53cafb40a0c0804b09eab418443fb8", size = 1357661, upload-time = "2026-06-17T22:04:45.369Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/89/293fc625963d8adb61828edeeb348ee5eab8d9707f63771f2035d83cd16b/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bcd83941a84b89fc2f5dac40b10b7736a5602766f33afcd554545b0bf770fdc2", size = 1274822, upload-time = "2026-06-17T22:04:02.448Z" },
+    { url = "https://files.pythonhosted.org/packages/26/82/59b3f0e580519d07c0f9176ac9a47fca25e0d539284f9355d503d1139126/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44b270a4c40daf3b11a5d96694357c4ff99842e82c514281b2910eae4a5d653a", size = 1501770, upload-time = "2026-06-17T22:03:33.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/25/7d11adf65f6ccbb22929a5d842e3707a1f98ea5bf041f842c72d1a957b25/lmnr_claude_code_proxy-0.1.23-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e8ef14e4b592cfd27d057b47a25e9f62e6d900a95ed244c4acb3316b76f6034f", size = 1469005, upload-time = "2026-06-17T22:03:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/81/84/9f4de95e2789b59e2f4a5c65c4f7745743a85553bc7b97444aecf09edea6/lmnr_claude_code_proxy-0.1.23-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a77258d487989bf23ec6807e21cd2c334e9e457e9f854875a0c253cb04260387", size = 1648912, upload-time = "2026-06-17T22:04:59.001Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a5/c48aaa153629db2818849638b28166239a06ce351ea805576e369a10397c/lmnr_claude_code_proxy-0.1.23-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:2d6c4bf49bd060146577022d2f45a9921ce5604289d7f52db357fd3d5aeac838", size = 1463928, upload-time = "2026-06-17T22:03:36.082Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4c/8bb6cb1c11a1474361ae52610965f3ac3f8ac52d3d5d0e83da60989efdc5/lmnr_claude_code_proxy-0.1.23-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8b43a95fdf053fc4ebc0723363d9f88aa5060078733f9df6b3e991235c473a96", size = 1526261, upload-time = "2026-06-17T22:04:26.804Z" },
+    { url = "https://files.pythonhosted.org/packages/85/00/e761878f5ff53a5d9de5c5b8b8420d7b9f8473c0cafb34f3d94255016e9b/lmnr_claude_code_proxy-0.1.23-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9e7a58160b8c327e9fddbba828c86bb1084967519a160ae4f64d0ae01d65730b", size = 1720713, upload-time = "2026-06-17T22:03:01.577Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3d/25ac768a6e3a8e6e14b0571e6f6e5526a2c557337ee8a63dd640e2673fdc/lmnr_claude_code_proxy-0.1.23-cp312-cp312-win32.whl", hash = "sha256:d7ac385abe119b21aaf8ab1c1aee7f9dcdd8a03a3a00aad331f3326b6aac075c", size = 1077961, upload-time = "2026-06-17T22:03:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/5e/17f625ff97eae59ad6cd4f1e82c687dc291b7d8e50fc9d87300d5101b12b/lmnr_claude_code_proxy-0.1.23-cp312-cp312-win_amd64.whl", hash = "sha256:53c6d47ad2bea70dda75a642a3d8fa7b4fbb68c718958d37a5f994ff6f98d210", size = 1314902, upload-time = "2026-06-17T22:04:33.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/21/3441b032c060165d4f6eab6c4a89abdab7c369e1c42a6d3d66d61ea79d7c/lmnr_claude_code_proxy-0.1.23-cp312-cp312-win_arm64.whl", hash = "sha256:7192a72122633ce7d92e2ae4d3df53854c2aa3dddccf4f8c5155d0dfe3e574ab", size = 1240245, upload-time = "2026-06-17T22:03:55.958Z" },
 ]
 
 [[package]]
@@ -1750,8 +1773,8 @@ dev = [
 requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.10.1,<0.11.0" },
     { name = "httpx", specifier = ">=0.25.0" },
-    { name = "openhands-sdk", specifier = "==1.31.0" },
-    { name = "openhands-tools", specifier = "==1.31.0" },
+    { name = "openhands-sdk", specifier = "==1.41.0" },
+    { name = "openhands-tools", specifier = "==1.41.0" },
     { name = "openhands-workspace", specifier = "==1.11.1" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyperclip", specifier = ">=1.9.0" },
@@ -1808,7 +1831,7 @@ wheels = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.31.0"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -1829,14 +1852,14 @@ dependencies = [
     { name = "tree-sitter-bash" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/1e/f73c96c83576eb35eae11d5c9f186a8101a238496addc260b998a22647a5/openhands_sdk-1.31.0.tar.gz", hash = "sha256:a076bd08f0242ae306dcd76a19b402c9da8fb5a45faf05dc6c9118e52708383b", size = 598904, upload-time = "2026-07-02T18:58:27.103Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/ee/a938c78fdd310022c9081445195047207f06fabb2650abb9c1c04e44f66d/openhands_sdk-1.41.0.tar.gz", hash = "sha256:b12bb6f5a69bfee476a4ae8700b0bf33c478f67ea708c8d4a5f75a95d6f4045f", size = 655650, upload-time = "2026-08-06T13:29:47.255Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/37/789050577860e30e8a4808bdfd8d8c8215a866564161853eb8c97b9df60c/openhands_sdk-1.31.0-py3-none-any.whl", hash = "sha256:fe690ce1c9ab14e1b505dd42f9f6504b3fa89cbf23cb7267a871e1c26f718085", size = 720101, upload-time = "2026-07-02T18:58:21.639Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/77/d7ac6b913d0c4baef3989f2fc062c968b7f6d5f276a1a7d29ba136916344/openhands_sdk-1.41.0-py3-none-any.whl", hash = "sha256:3fcd1ff4ef93c49a37ed1095d36c69714711661a0e8e7812882088af3a6d0427", size = 782965, upload-time = "2026-08-06T13:29:42.036Z" },
 ]
 
 [[package]]
 name = "openhands-tools"
-version = "1.31.0"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "binaryornot" },
@@ -1850,9 +1873,9 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-bash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/b4/00234765d2fe88e08f5df545e81b4689846b2d9bb56b779ac90dc1e9ddc3/openhands_tools-1.31.0.tar.gz", hash = "sha256:33ce3a4109685c91c00a6b28f543b2dffa6316c71ba542b2c63086553eea65f9", size = 145885, upload-time = "2026-07-02T18:58:28.195Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/dc/d39fa6f6471ad9c5ccf81ca17a905f9d4212bdd21fdf8cd4299eaf320ef6/openhands_tools-1.41.0.tar.gz", hash = "sha256:93bbfe1b6b289a379e656b84167ba4b163f5f2778d48cc2cce1f2507bf21ac9a", size = 146945, upload-time = "2026-08-06T13:29:48.497Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/e6/83de568fa4aecd8dd78d943a76e1a936faad7d780b82d56e22de68304fbb/openhands_tools-1.31.0-py3-none-any.whl", hash = "sha256:b1fe85efae5072f9bcf21f2b6147ca5f458ad7cb71e5c8467311126ee7d3f54e", size = 191219, upload-time = "2026-07-02T18:58:23.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/bb/13dde3fe60070d01e255a455488f0398fff89a58d418a22ed558921d9e45/openhands_tools-1.41.0-py3-none-any.whl", hash = "sha256:88c9f64d07e5298895698c806e9a1c03c41ecf552e68b61cc54c729685bbc2b4", size = 192423, upload-time = "2026-08-06T13:29:43.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN: Newer SDK/LiteLLM  would be nice to have access to. Tested with Toad for ACP changes and with https://mcp.deepwiki.com/mcp for MCP changes.  Broken into 2 commits if prefer to only update to SDK 1.31.0 for now.

<!-- Human contributors: add a short note about your testing. -->

AGENT:

<!-- AI/LLM agents:
Do not edit the HUMAN section.
In this AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

End-to-end verification performed:

1. **Dependency resolution & install**: `uv lock` resolved cleanly, bumping
   `openhands-sdk` and `openhands-tools`  to 1.41.0. `uv sync` installed
   the new versions with no errors. Verified the installed version reports
   `1.41.0`.

2. **Full test suite**: `uv run pytest -q` → 1428 passed, 3 failed. The 3
   failures are a pre-existing `asyncio.get_event_loop()` test-isolation issue
   in `tests/test_web_command.py` (confirmed to fail identically on unmodified
   `main` under the same full-suite run, and to pass in isolation) — unrelated
   to the SDK version.

3. **MCP coercion runtime check**: Verified at runtime that the migration
   helpers behave correctly:
   - Legacy `{"mcpServers": ...}` wrapper → flat `dict[str, MCPServer]`
   - fastmcp string auth `"oauth"` → `strategy='oauth2'`
   - fastmcp bearer token `"tok123"` → `strategy='bearer'` with secret value preserved
   - `MCPServer` dump round-trips cleanly via `dump_mcp_config`
   - `getattr(server.auth, "strategy", None)` returns `None` safely when `auth` is `None`

---

## Why

`openhands-sdk` 1.28.1 is outdated. Along the upgrade path to 1.41.0, the SDK
introduced two API changes that require CLI code changes:

- **`agent-client-protocol` 0.10.x** renamed/reshaped ACP schema types
  (`AuthMethod` → `AuthMethodAgent`, new `close_session`, new kwargs) that the
  CLI's `acp_impl` must conform to.
- **SDK >= 1.32** changed `Agent.mcp_config` from an opaque
  `{"mcpServers": ...}` wrapper to a flat `dict[str, MCPServer]`. Every CLI
  code path reading or writing `mcp_config` needed updating, and persisted
  agents saved by older versions need coercion on load.

## Summary

- Bump `openhands-sdk` / `openhands-tools` from 1.28.1 to 1.41.0 and
  `agent-client-protocol` to `>=0.10.1,<0.11.0`; port `acp_impl` to the 0.10.x
  ACP API.
- Migrate all `mcp_config` handling to the flat `dict[str, MCPServer]` format,
  including backward-compat coercion of legacy `{"mcpServers": ...}` persisted
  agents on load.
- Migrate tests/fixtures to the flat format; add regression tests for legacy
  wrapper coercion, string auth, ACP header conversion, and the "Incoming on
  Restart" panel comparison.

## Issue Number

#786

## How to Test

```bash
git clone git@github.com:cbagwell/OpenHands-CLI.git
cd OpenHands-CLI
git checkout chore/bump-openhands-sdk-1.41.0
uv sync
uv run pytest -q
```

Expected: 1428 passed, 3 failed (the 3 test_web_command.py failures are
pre-existing event-loop isolation issues, not introduced by this PR — they
fail identically on main).

To specifically verify the MCP migration paths:

```bash
uv run pytest tests/settings/test_mcp_settings_reconciliation.py \
             tests/tui/panels/test_mcp_side_panel.py \
             tests/test_utils.py tests/acp/test_confirmation.py \
             tests/snapshots/test_app_snapshots.py -q
```

Expected: all pass.

## Video/Screenshots

N/A — this is a dependency bump and internal API migration with no UI changes.
Snapshot tests (tests/snapshots/test_app_snapshots.py) confirm the TUI renders
identically before and after the migration.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [X] Docs / chore

## Notes

* Backward compatibility: load_from_disk coerces pre-1.32 persisted
{"mcpServers": ...} wrappers to the flat format at load, so existing users
won't see a "corrupted file" error on upgrade. An uncoercible MCP config is
dropped (not fatal); genuinely corrupted non-MCP fields still surface as
corrupted. Covered by test_load_legacy_persisted_mcp_wrapper,
test_load_persisted_mcp_with_fastmcp_string_auth,
test_load_uncoercible_persisted_mcp_is_dropped, and
test_load_non_mcp_validation_error_reports_corrupted.