### PR TITLE
docs: mark project as no longer actively maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ Run OpenHands agent inside your terminal, favorite IDE, CI pipelines, local brow
 
 ## Project status
 
-OpenHands V1 CLI is **feature-complete** and primarily maintained for stability.
-Expect only major bug fixes and compatibility updates; new features are unlikely.
+> ⚠️ **This project is no longer actively maintained.**
 
-For active feature development, see [OpenHands](https://github.com/OpenHands/OpenHands) or join the [Slack](https://dub.sh/openhands].
+We recommend using [Agent Canvas](https://github.com/OpenHands/OpenHands) for an entirely open source, customizable, and local AI coding agent experience. See the [Agent Canvas installation docs](https://docs.openhands.dev/openhands/usage/agent-canvas/overview) to get started.
 
 
 ## Installation


### PR DESCRIPTION
## What changed

Updated the **Project status** section at the top of the README to indicate that this project is no longer actively maintained.

The previous status (feature-complete, primarily maintained for stability) is replaced with a deprecation notice that recommends [Agent Canvas](https://github.com/OpenHands/OpenHands) (in the OpenHands/OpenHands main repo) for an entirely open source, customizable, and local AI coding agent experience, and links to the [Agent Canvas installation docs](https://docs.openhands.dev/openhands/usage/agent-canvas/overview).

## Why

The CLI is no longer under active development; users should be directed to Agent Canvas, the recommended alternative for a local, open-source, customizable AI coding agent experience.

## Changes

- `README.md`: replaced the "Project status" section with a deprecation notice + Agent Canvas recommendation and docs link.

## Verification

Documentation-only change; no code or tests affected.

---

_This PR was created by an AI agent (OpenHands) on behalf of the repository owner._

@jpelletier1 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/298a3dd1-6b8b-4747-ba5a-e2d86fedee96)

---

## 🚀 Try this PR

```bash
uvx --python 3.12 git+https://github.com/OpenHands/OpenHands-CLI.git@readme-deprecation-notice
```