### PR TITLE
cli: add an unattended execution contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,41 @@ openhands --headless -f instructions.md  # or use a file
 openhands --headless --json -t "Create a Flask app"
 ```
 
+### Unattended automation
+
+Use `openhands run` for CI, benchmark harnesses, and other callers that need a
+noninteractive process contract. It never opens the TUI or onboarding, requires
+model configuration from the environment, streams JSONL on stdout, and
+continuously writes the same stream plus SDK conversation state under the
+selected output directory.
+
+```bash
+LLM_API_KEY="$PROVIDER_API_KEY" \
+LLM_MODEL="openai/model-name" \
+LLM_BASE_URL="https://provider.example/v1" \
+openhands run \
+  --task "Fix the failing test" \
+  --workspace /workspace \
+  --output-dir /logs/openhands \
+  --offline \
+  --no-user-skills
+```
+
+`--offline` disables optional startup fetches such as public skills. The output
+directory contains:
+
+- `events.jsonl`: a flushed event and lifecycle stream that matches stdout.
+- `run.json`: an atomically replaced summary with status, conversation ID,
+  workspace, timestamps, and exit code.
+- `conversations/<id>/`: the SDK's incrementally persisted conversation state
+  and individual event files.
+
+Exit codes are stable for automation: `0` completed, `2` command usage, `3`
+configuration, `4` model provider, `5` agent execution, and `6` internal CLI
+failure. Signals use the conventional `128 + signal` value (for example, `143`
+for `SIGTERM`). A supervisor process preserves the terminal summary and partial
+events when an in-flight provider request does not stop cooperatively.
+
 ### Resume Conversations
 
 ```bash

--- a/openhands_cli/argparsers/main_parser.py
+++ b/openhands_cli/argparsers/main_parser.py
@@ -7,6 +7,7 @@ from openhands_cli.argparsers.acp_parser import add_acp_parser
 from openhands_cli.argparsers.auth_parser import add_login_parser, add_logout_parser
 from openhands_cli.argparsers.cloud_parser import add_cloud_parser
 from openhands_cli.argparsers.mcp_parser import add_mcp_parser
+from openhands_cli.argparsers.run_parser import add_run_parser
 from openhands_cli.argparsers.serve_parser import add_serve_parser
 from openhands_cli.argparsers.util import (
     add_confirmation_mode_args,
@@ -112,6 +113,9 @@ def create_main_parser() -> argparse.ArgumentParser:
 
     # Add acp subcommands
     add_acp_parser(subparsers)
+
+    # Add unattended run subcommand
+    add_run_parser(subparsers)
 
     # Add serve subcommand
     add_serve_parser(subparsers)

--- a/openhands_cli/argparsers/run_parser.py
+++ b/openhands_cli/argparsers/run_parser.py
@@ -1,0 +1,64 @@
+import argparse
+from pathlib import Path
+
+
+def add_run_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "run",
+        help="Run one task unattended with JSONL output and durable artifacts",
+        description=(
+            "Run OpenHands without a terminal UI or interactive fallback. "
+            "LLM_API_KEY and LLM_MODEL are required; LLM_BASE_URL is optional."
+        ),
+    )
+    task_source = parser.add_mutually_exclusive_group(required=True)
+    task_source.add_argument("-t", "--task", help="Task text to execute")
+    task_source.add_argument(
+        "-f",
+        "--file",
+        type=Path,
+        help="UTF-8 file containing the task text",
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        required=True,
+        help="Existing writable workspace OpenHands may modify",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory for events.jsonl and run.json",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Disable optional startup network fetches, including public skills",
+    )
+    parser.add_argument(
+        "--no-public-skills",
+        dest="load_public_skills",
+        action="store_false",
+        default=True,
+        help="Do not fetch or load the OpenHands public skills repository",
+    )
+    parser.add_argument(
+        "--no-user-skills",
+        dest="load_user_skills",
+        action="store_false",
+        default=True,
+        help="Do not load skills from user-level directories",
+    )
+    parser.add_argument(
+        "--llm-timeout",
+        type=int,
+        default=300,
+        help="Provider request timeout in seconds (default: 300)",
+    )
+    parser.add_argument(
+        "--llm-retries",
+        type=int,
+        default=5,
+        help="Provider request retry count (default: 5)",
+    )

--- a/openhands_cli/entrypoint.py
+++ b/openhands_cli/entrypoint.py
@@ -6,6 +6,7 @@ This is a simplified version that demonstrates the TUI functionality.
 
 import argparse
 import logging
+import multiprocessing
 import os
 import sys
 import warnings
@@ -25,11 +26,6 @@ from openhands_cli.utils import create_seeded_instructions_from_args
 
 
 console = Console()
-
-
-env_path = Path.cwd() / ".env"
-if env_path.is_file():
-    load_dotenv(dotenv_path=str(env_path), override=False)
 
 
 debug_env = os.getenv("DEBUG", "false").lower()
@@ -94,8 +90,14 @@ def main() -> None:
         ImportError: If agent chat dependencies are missing
         Exception: On other error conditions
     """
+    multiprocessing.freeze_support()
     parser = create_main_parser()
     args = parser.parse_args()
+
+    if args.command != "run":
+        env_path = Path.cwd() / ".env"
+        if env_path.is_file():
+            load_dotenv(dotenv_path=str(env_path), override=False)
 
     # Handle --json flag (only works with --headless)
     json_mode = args.json and args.headless
@@ -115,11 +117,15 @@ def main() -> None:
     critic_disabled = args.headless
 
     # Warn about env vars if they are set but not being used
-    if not env_overrides_enabled:
+    if args.command != "run" and not env_overrides_enabled:
         check_and_warn_env_vars()
 
     try:
-        if args.command == "serve":
+        if args.command == "run":
+            from openhands_cli.unattended import run_unattended
+
+            sys.exit(run_unattended(args))
+        elif args.command == "serve":
             # Import gui_launcher only when needed
             from openhands_cli.gui_launcher import launch_gui_server
 

--- a/openhands_cli/setup.py
+++ b/openhands_cli/setup.py
@@ -33,6 +33,11 @@ def load_agent_specs(
     *,
     env_overrides_enabled: bool = False,
     critic_disabled: bool = False,
+    ignore_persisted_agent: bool = False,
+    load_user_skills: bool = True,
+    load_public_skills: bool = True,
+    llm_timeout: int | None = None,
+    llm_num_retries: int | None = None,
 ) -> Agent:
     """Load agent specifications.
 
@@ -56,6 +61,11 @@ def load_agent_specs(
         session_id=conversation_id,
         env_overrides_enabled=env_overrides_enabled,
         critic_disabled=critic_disabled,
+        ignore_persisted_agent=ignore_persisted_agent,
+        load_user_skills=load_user_skills,
+        load_public_skills=load_public_skills,
+        llm_timeout=llm_timeout,
+        llm_num_retries=llm_num_retries,
     )
     if not agent:
         raise MissingAgentSpec(
@@ -100,6 +110,11 @@ def setup_conversation(
     *,
     env_overrides_enabled: bool = False,
     critic_disabled: bool = False,
+    ignore_persisted_agent: bool = False,
+    load_user_skills: bool = True,
+    load_public_skills: bool = True,
+    llm_timeout: int | None = None,
+    llm_num_retries: int | None = None,
 ) -> BaseConversation:
     """
     Setup the conversation with agent.
@@ -133,6 +148,11 @@ def setup_conversation(
         str(conversation_id),
         env_overrides_enabled=env_overrides_enabled,
         critic_disabled=critic_disabled,
+        ignore_persisted_agent=ignore_persisted_agent,
+        load_user_skills=load_user_skills,
+        load_public_skills=load_public_skills,
+        llm_timeout=llm_timeout,
+        llm_num_retries=llm_num_retries,
     )
 
     # Prepare callbacks list

--- a/openhands_cli/stores/agent_store.py
+++ b/openhands_cli/stores/agent_store.py
@@ -320,6 +320,11 @@ class AgentStore:
         *,
         env_overrides_enabled: bool = False,
         critic_disabled: bool = False,
+        ignore_persisted_agent: bool = False,
+        load_user_skills: bool = True,
+        load_public_skills: bool = True,
+        llm_timeout: int | None = None,
+        llm_num_retries: int | None = None,
     ) -> Agent | None:
         """Load an Agent and apply runtime configuration.
 
@@ -350,7 +355,7 @@ class AgentStore:
                 required env variables are missing.
         """
 
-        agent = self.load_from_disk()
+        agent = None if ignore_persisted_agent else self.load_from_disk()
         overrides = LLMEnvOverrides.from_env(enabled=env_overrides_enabled)
 
         if env_overrides_enabled:
@@ -365,6 +370,10 @@ class AgentStore:
             agent,
             session_id,
             critic_disabled=critic_disabled,
+            load_user_skills=load_user_skills,
+            load_public_skills=load_public_skills,
+            llm_timeout=llm_timeout,
+            llm_num_retries=llm_num_retries,
         )
 
     def _resolve_tools(self, session_id: str | None) -> list[Tool]:
@@ -405,7 +414,12 @@ class AgentStore:
             }
         )
 
-    def _build_agent_context(self) -> AgentContext:
+    def _build_agent_context(
+        self,
+        *,
+        load_user_skills: bool = True,
+        load_public_skills: bool = True,
+    ) -> AgentContext:
         skills = load_project_skills(get_work_dir())
         system_suffix = "\n".join(
             [
@@ -416,12 +430,16 @@ class AgentStore:
         return AgentContext(
             skills=skills,
             system_message_suffix=system_suffix,
-            load_user_skills=True,
-            load_public_skills=True,
+            load_user_skills=load_user_skills,
+            load_public_skills=load_public_skills,
         )
 
     def _maybe_build_condenser(
-        self, agent: Agent, *, session_id: str | None
+        self,
+        agent: Agent,
+        *,
+        session_id: str | None,
+        llm_updates: dict[str, int],
     ) -> LLMSummarizingCondenser | None:
         if not (
             agent.condenser and isinstance(agent.condenser, LLMSummarizingCondenser)
@@ -431,6 +449,8 @@ class AgentStore:
         condenser_llm = self._with_llm_metadata(
             agent.condenser.llm, session_id=session_id, llm_type="condenser"
         )
+        if llm_updates:
+            condenser_llm = condenser_llm.model_copy(update=llm_updates)
 
         return agent.condenser.model_copy(update={"llm": condenser_llm})
 
@@ -440,18 +460,37 @@ class AgentStore:
         session_id: str | None = None,
         *,
         critic_disabled: bool = False,
+        load_user_skills: bool = True,
+        load_public_skills: bool = True,
+        llm_timeout: int | None = None,
+        llm_num_retries: int | None = None,
     ) -> Agent:
         updated_tools = self._resolve_tools(session_id)
         updated_llm = self._with_llm_metadata(
             agent.llm, session_id=session_id, llm_type="agent"
         )
+        llm_updates = {
+            key: value
+            for key, value in {
+                "timeout": llm_timeout,
+                "num_retries": llm_num_retries,
+            }.items()
+            if value is not None
+        }
+        if llm_updates:
+            updated_llm = updated_llm.model_copy(update=llm_updates)
 
-        agent_context = self._build_agent_context()
+        agent_context = self._build_agent_context(
+            load_user_skills=load_user_skills,
+            load_public_skills=load_public_skills,
+        )
 
         enabled_servers = list_enabled_servers()
         mcp_config = {"mcpServers": enabled_servers} if enabled_servers else {}
 
-        condenser = self._maybe_build_condenser(agent, session_id=session_id)
+        condenser = self._maybe_build_condenser(
+            agent, session_id=session_id, llm_updates=llm_updates
+        )
 
         critic = None
         if not critic_disabled:

--- a/openhands_cli/unattended.py
+++ b/openhands_cli/unattended.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import argparse
+import json
+import multiprocessing
+import os
+import signal
+import uuid
+from datetime import UTC, datetime
+from enum import IntEnum
+from pathlib import Path
+from types import FrameType
+from typing import Any
+
+from rich.console import Console
+
+from openhands.sdk import BaseConversation, Message, TextContent
+from openhands.sdk.conversation.exceptions import ConversationRunError
+from openhands.sdk.event.base import Event
+from openhands.sdk.llm.exceptions import (
+    LLMAuthenticationError,
+    LLMBadRequestError,
+    LLMContextWindowExceedError,
+    LLMNoResponseError,
+    LLMRateLimitError,
+    LLMServiceUnavailableError,
+    LLMTimeoutError,
+)
+from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands_cli.setup import setup_conversation
+from openhands_cli.stores import MissingEnvironmentVariablesError
+
+
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    USAGE = 2
+    CONFIGURATION = 3
+    PROVIDER = 4
+    AGENT = 5
+    INTERNAL = 6
+
+
+class JsonlEventStream:
+    def __init__(self, output_dir: Path, *, append: bool = False) -> None:
+        self.output_dir = output_dir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.path = self.output_dir / "events.jsonl"
+        self._file = self.path.open("a" if append else "w", encoding="utf-8")
+
+    def _emit(self, record: dict[str, Any]) -> None:
+        line = json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+        print(line, flush=True)
+        self._file.write(line + "\n")
+        self._file.flush()
+        os.fsync(self._file.fileno())
+
+    def emit_event(self, event: Event) -> None:
+        self._emit({"type": "event", "event": json.loads(event.model_dump_json())})
+
+    def emit_lifecycle(self, event_type: str, **fields: Any) -> None:
+        self._emit({"type": event_type, **fields})
+
+    def close(self) -> None:
+        self._file.close()
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def validate_run_paths(
+    workspace: Path, output_dir: Path, *, allow_existing: bool = False
+) -> tuple[Path, Path]:
+    workspace = workspace.expanduser().resolve()
+    output_dir = output_dir.expanduser().resolve()
+    if not workspace.exists():
+        raise ValueError(f"Workspace does not exist: {workspace}")
+    if not workspace.is_dir():
+        raise ValueError(f"Workspace is not a directory: {workspace}")
+    if not os.access(workspace, os.W_OK | os.X_OK):
+        raise ValueError(f"Workspace is not writable: {workspace}")
+    if not allow_existing:
+        for filename in ("events.jsonl", "run.json"):
+            if (output_dir / filename).exists():
+                raise ValueError(
+                    f"Output directory already contains {filename}: {output_dir}"
+                )
+    return workspace, output_dir
+
+
+_PROVIDER_MODULES = ("anthropic", "httpcore", "httpx", "litellm", "openai")
+_PROVIDER_ERRORS = (
+    LLMAuthenticationError,
+    LLMBadRequestError,
+    LLMContextWindowExceedError,
+    LLMNoResponseError,
+    LLMRateLimitError,
+    LLMServiceUnavailableError,
+    LLMTimeoutError,
+)
+
+
+def classify_run_error(error: BaseException) -> ExitCode:
+    current: BaseException | None = error
+    while current is not None:
+        if isinstance(current, _PROVIDER_ERRORS):
+            return ExitCode.PROVIDER
+        module = type(current).__module__.split(".", 1)[0]
+        if module in _PROVIDER_MODULES:
+            return ExitCode.PROVIDER
+        current = current.__cause__ or current.__context__
+    return ExitCode.AGENT
+
+
+def _safe_error_message(error: BaseException) -> str:
+    message = str(error)
+    for name in ("LLM_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
+        value = os.environ.get(name)
+        if value:
+            message = message.replace(value, "[REDACTED]")
+    return message[:2000]
+
+
+def _write_summary(output_dir: Path, summary: dict[str, Any]) -> None:
+    target = output_dir / "run.json"
+    temporary = output_dir / ".run.json.tmp"
+    temporary.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, target)
+
+
+def _task_from_args(args: argparse.Namespace) -> str:
+    if args.task is not None:
+        return args.task
+    try:
+        return args.file.expanduser().read_text(encoding="utf-8")
+    except OSError as error:
+        raise ValueError(f"Unable to read task file {args.file}: {error}") from error
+
+
+def _run_worker(args: argparse.Namespace) -> int:
+    started_at = utc_now()
+    output_dir = args.output_dir.expanduser().resolve()
+    stream: JsonlEventStream | None = None
+    conversation: BaseConversation | None = None
+    received_signal: int | None = None
+    previous_environment: dict[str, str | None] = {}
+    previous_handlers: dict[int, Any] = {}
+    summary: dict[str, Any] = {
+        "status": "internal_error",
+        "exit_code": int(ExitCode.INTERNAL),
+        "started_at": started_at,
+    }
+
+    def handle_signal(signum: int, _frame: FrameType | None) -> None:
+        nonlocal received_signal
+        received_signal = signum
+        if stream is not None:
+            stream.emit_lifecycle("run.interrupt_requested", signal=signum)
+        if conversation is not None:
+            conversation.interrupt()
+
+    try:
+        workspace, output_dir = validate_run_paths(
+            args.workspace, args.output_dir, allow_existing=True
+        )
+        task = _task_from_args(args)
+        if not task.strip():
+            raise ValueError("Task must not be empty")
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        stream = JsonlEventStream(output_dir)
+        conversation_id = args.conversation_id
+        summary.update(
+            {
+                "conversation_id": conversation_id.hex,
+                "workspace": str(workspace),
+                "output_dir": str(output_dir),
+            }
+        )
+        stream.emit_lifecycle(
+            "run.started",
+            conversation_id=conversation_id.hex,
+            workspace=str(workspace),
+        )
+
+        environment = {
+            "OPENHANDS_WORK_DIR": str(workspace),
+            "OPENHANDS_PERSISTENCE_DIR": str(output_dir / "state"),
+            "OPENHANDS_CONVERSATIONS_DIR": str(output_dir / "conversations"),
+        }
+        for name, value in environment.items():
+            previous_environment[name] = os.environ.get(name)
+            os.environ[name] = value
+
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[signum] = signal.getsignal(signum)
+            signal.signal(signum, handle_signal)
+
+        load_public_skills = args.load_public_skills and not args.offline
+        conversation = setup_conversation(
+            conversation_id,
+            confirmation_policy=NeverConfirm(),
+            event_callback=stream.emit_event,
+            console=Console(stderr=True, highlight=False),
+            env_overrides_enabled=True,
+            critic_disabled=True,
+            ignore_persisted_agent=True,
+            load_user_skills=args.load_user_skills,
+            load_public_skills=load_public_skills,
+            llm_timeout=args.llm_timeout,
+            llm_num_retries=args.llm_retries,
+        )
+        conversation.send_message(
+            Message(role="user", content=[TextContent(text=task)])
+        )
+        conversation.run()
+
+        if received_signal is not None:
+            exit_code = 128 + received_signal
+            summary.update(
+                {
+                    "status": "interrupted",
+                    "exit_code": exit_code,
+                    "signal": received_signal,
+                }
+            )
+            stream.emit_lifecycle(
+                "run.interrupted", exit_code=exit_code, signal=received_signal
+            )
+            return exit_code
+
+        summary.update({"status": "completed", "exit_code": int(ExitCode.SUCCESS)})
+        stream.emit_lifecycle("run.completed", exit_code=int(ExitCode.SUCCESS))
+        return int(ExitCode.SUCCESS)
+    except (MissingEnvironmentVariablesError, ValueError) as error:
+        summary.update(
+            {
+                "status": "configuration_error",
+                "exit_code": int(ExitCode.CONFIGURATION),
+                "error_type": type(error).__name__,
+                "error_message": _safe_error_message(error),
+            }
+        )
+        if stream is not None:
+            stream.emit_lifecycle(
+                "run.failed",
+                exit_code=int(ExitCode.CONFIGURATION),
+                error_category="configuration",
+                error_type=type(error).__name__,
+            )
+        return int(ExitCode.CONFIGURATION)
+    except ConversationRunError as error:
+        exit_code = classify_run_error(error.original_exception)
+        category = "provider" if exit_code == ExitCode.PROVIDER else "agent"
+        summary.update(
+            {
+                "status": f"{category}_error",
+                "exit_code": int(exit_code),
+                "error_type": type(error.original_exception).__name__,
+                "error_message": _safe_error_message(error.original_exception),
+            }
+        )
+        if stream is not None:
+            stream.emit_lifecycle(
+                "run.failed",
+                exit_code=int(exit_code),
+                error_category=category,
+                error_type=type(error.original_exception).__name__,
+            )
+        return int(exit_code)
+    except Exception as error:
+        summary.update(
+            {
+                "status": "internal_error",
+                "exit_code": int(ExitCode.INTERNAL),
+                "error_type": type(error).__name__,
+                "error_message": _safe_error_message(error),
+            }
+        )
+        if stream is not None:
+            stream.emit_lifecycle(
+                "run.failed",
+                exit_code=int(ExitCode.INTERNAL),
+                error_category="internal",
+                error_type=type(error).__name__,
+            )
+        return int(ExitCode.INTERNAL)
+    finally:
+        summary["finished_at"] = utc_now()
+        if conversation is not None:
+            conversation.close()
+        if output_dir.exists():
+            _write_summary(output_dir, summary)
+        if stream is not None:
+            stream.close()
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+        for name, value in previous_environment.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
+def _worker_entry(args: argparse.Namespace) -> None:
+    raise SystemExit(_run_worker(args))
+
+
+def run_unattended(args: argparse.Namespace) -> int:
+    try:
+        workspace, output_dir = validate_run_paths(args.workspace, args.output_dir)
+        task = _task_from_args(args)
+        if not task.strip():
+            raise ValueError("Task must not be empty")
+    except ValueError as error:
+        output_dir = args.output_dir.expanduser().resolve()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        summary = {
+            "status": "configuration_error",
+            "exit_code": int(ExitCode.CONFIGURATION),
+            "started_at": utc_now(),
+            "finished_at": utc_now(),
+            "error_type": type(error).__name__,
+            "error_message": _safe_error_message(error),
+        }
+        _write_summary(output_dir, summary)
+        return int(ExitCode.CONFIGURATION)
+
+    args.workspace = workspace
+    args.output_dir = output_dir
+    args.task = task
+    args.file = None
+    args.conversation_id = uuid.uuid4()
+    started_at = utc_now()
+    running_summary = {
+        "status": "running",
+        "exit_code": None,
+        "started_at": started_at,
+        "conversation_id": args.conversation_id.hex,
+        "workspace": str(workspace),
+        "output_dir": str(output_dir),
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _write_summary(output_dir, running_summary)
+
+    context = multiprocessing.get_context("spawn")
+    process = context.Process(target=_worker_entry, args=(args,))
+    received_signal: int | None = None
+    previous_handlers: dict[int, Any] = {}
+
+    def handle_signal(signum: int, _frame: FrameType | None) -> None:
+        nonlocal received_signal
+        received_signal = signum
+        if process.is_alive():
+            process.terminate()
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        previous_handlers[signum] = signal.getsignal(signum)
+        signal.signal(signum, handle_signal)
+
+    try:
+        process.start()
+        while process.is_alive():
+            process.join(timeout=0.1)
+            if received_signal is not None:
+                process.join(timeout=3)
+                if process.is_alive():
+                    process.kill()
+                    process.join(timeout=3)
+                break
+
+        if received_signal is not None:
+            exit_code = 128 + received_signal
+            summary = {
+                **running_summary,
+                "status": "interrupted",
+                "exit_code": exit_code,
+                "signal": received_signal,
+                "finished_at": utc_now(),
+            }
+            stream = JsonlEventStream(output_dir, append=True)
+            stream.emit_lifecycle(
+                "run.interrupted", exit_code=exit_code, signal=received_signal
+            )
+            stream.close()
+            _write_summary(output_dir, summary)
+            return exit_code
+
+        if process.exitcode is None:
+            exit_code = int(ExitCode.INTERNAL)
+        elif process.exitcode < 0 or process.exitcode > int(ExitCode.INTERNAL):
+            exit_code = int(ExitCode.INTERNAL)
+        else:
+            exit_code = process.exitcode
+
+        if exit_code == int(ExitCode.INTERNAL):
+            current_summary = json.loads((output_dir / "run.json").read_text())
+            if current_summary.get("status") == "running":
+                current_summary.update(
+                    {
+                        "status": "internal_error",
+                        "exit_code": exit_code,
+                        "finished_at": utc_now(),
+                        "error_type": "WorkerProcessError",
+                        "error_message": (
+                            f"Agent worker exited with code {process.exitcode}"
+                        ),
+                    }
+                )
+                _write_summary(output_dir, current_summary)
+        return exit_code
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)

--- a/tests/test_unattended.py
+++ b/tests/test_unattended.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from openhands.sdk import Message
+from openhands.sdk.event import MessageEvent
+from openhands.sdk.llm.exceptions import LLMAuthenticationError
+from openhands_cli.argparsers.main_parser import create_main_parser
+from openhands_cli.unattended import (
+    ExitCode,
+    JsonlEventStream,
+    classify_run_error,
+    validate_run_paths,
+)
+
+
+def test_run_parser_exposes_unattended_contract(tmp_path: Path):
+    parser = create_main_parser()
+    workspace = tmp_path / "workspace"
+    output = tmp_path / "output"
+    workspace.mkdir()
+
+    args = parser.parse_args(
+        [
+            "run",
+            "--task",
+            "Fix the bug",
+            "--workspace",
+            str(workspace),
+            "--output-dir",
+            str(output),
+            "--offline",
+            "--no-user-skills",
+            "--llm-timeout",
+            "60",
+            "--llm-retries",
+            "2",
+        ]
+    )
+
+    assert args.command == "run"
+    assert args.task == "Fix the bug"
+    assert args.workspace == workspace
+    assert args.output_dir == output
+    assert args.offline is True
+    assert args.load_user_skills is False
+    assert args.llm_timeout == 60
+    assert args.llm_retries == 2
+
+
+def test_run_parser_requires_exactly_one_task_source(tmp_path: Path):
+    parser = create_main_parser()
+    common = [
+        "run",
+        "--workspace",
+        str(tmp_path),
+        "--output-dir",
+        str(tmp_path / "output"),
+    ]
+
+    with pytest.raises(SystemExit) as missing:
+        parser.parse_args(common)
+    assert missing.value.code == ExitCode.USAGE
+
+    with pytest.raises(SystemExit) as duplicate:
+        parser.parse_args(common + ["--task", "one", "--file", "task.txt"])
+    assert duplicate.value.code == ExitCode.USAGE
+
+
+def test_validate_run_paths_rejects_missing_workspace(tmp_path: Path):
+    with pytest.raises(ValueError, match="Workspace does not exist"):
+        validate_run_paths(tmp_path / "missing", tmp_path / "output")
+
+
+def test_jsonl_event_stream_flushes_stdout_and_artifact(tmp_path: Path, capsys):
+    stream = JsonlEventStream(tmp_path)
+    event = MessageEvent(source="agent", llm_message=Message(role="assistant"))
+
+    stream.emit_event(event)
+    stream.emit_lifecycle("run.completed", exit_code=0)
+    stream.close()
+
+    stdout_lines = capsys.readouterr().out.splitlines()
+    artifact_lines = (tmp_path / "events.jsonl").read_text().splitlines()
+    assert stdout_lines == artifact_lines
+    assert json.loads(stdout_lines[0])["type"] == "event"
+    assert json.loads(stdout_lines[1]) == {
+        "type": "run.completed",
+        "exit_code": 0,
+    }
+
+
+def test_classify_run_error_distinguishes_provider_and_agent_failures():
+    provider_error = httpx.HTTPError("provider failed")
+
+    assert classify_run_error(provider_error) == ExitCode.PROVIDER
+    assert classify_run_error(LLMAuthenticationError()) == ExitCode.PROVIDER
+    assert classify_run_error(RuntimeError("agent loop failed")) == ExitCode.AGENT


### PR DESCRIPTION
## Summary

This adds an opt-in `openhands run` command for callers that need a fully
unattended process contract, while leaving the existing TUI and
`--headless` behavior unchanged.

Concrete downstream consumer and end-to-end validation:
[harbor-framework/harbor#3009](https://github.com/harbor-framework/harbor/pull/3009)
(ready for review; merge remains blocked on this PR, with Modal V2 validated downstream).

The command:

- never opens onboarding, confirmation prompts, or an interactive fallback;
- requires explicit `LLM_API_KEY` and `LLM_MODEL` process configuration and
  does not load a workspace `.env` file;
- requires explicit workspace and output directories;
- supports `--offline` / `--no-public-skills` so startup does not clone the
  public extensions repository;
- streams flushed JSONL to stdout and `events.jsonl` while the SDK also
  persists individual conversation events continuously;
- atomically maintains `run.json`, including while the run is active;
- supervises SDK execution so SIGINT/SIGTERM produce conventional exit codes
  and terminal artifacts even when a provider request does not stop
  cooperatively; and
- distinguishes usage (`2`), configuration (`3`), provider (`4`), agent (`5`),
  and internal CLI (`6`) failures.

## Why

The existing headless mode is useful for humans invoking a one-off task, but
benchmark and CI harnesses need a stronger boundary: fresh-home execution with
no TTY, no surprise startup fetches, an explicit workspace, incremental
machine-readable output, partial crash evidence, and trustworthy exit status.

This is also a concrete follow-up to #147 and the unresolved offline startup
failure reported in #483. I kept the new behavior opt-in because existing users
may depend on the current Textual-backed headless output.

I noticed that this repository was recently marked as no longer actively
maintained. A downstream Harbor adapter is being built against this exact
public command, but I would appreciate maintainer guidance on whether this CLI
repository remains the right home for the execution surface or whether it
should move elsewhere in the current OpenHands architecture.

## Reproduction evidence

Released `openhands==1.16.0` was installed into a fresh Python 3.12 Linux image
and exercised with stdin from `/dev/null`, no TTY, a fresh HOME, and a
deterministic OpenAI-compatible endpoint:

| Case | Observed result |
| --- | --- |
| Missing configuration | exit `1`; no run artifact |
| Final-only model response | exit `0`; JSONL and SDK session events persisted (the endpoint intentionally made no tool call) |
| GitHub unavailable | public-skills clone failed during startup; no supported flag could disable the fetch |
| Provider failure | still retrying after 45 s; harness sent SIGKILL (`137`) |
| SIGTERM during provider request | did not terminate within 25 s; harness sent SIGKILL (`137`) |
| Hard timeout / crash | low-level SDK event files survived, but no terminal run record |

The new command was then built from this branch and run in a disposable Linux
container with GitHub mapped to an unavailable address after installation:

| Case | Observed result |
| --- | --- |
| Nominal offline run | exit `0`; requested file created; 5 persisted SDK events; stdout exactly matched `events.jsonl`; zero public-skills paths |
| Missing configuration | exit `3`; `configuration_error` summary and `run.failed` record |
| Provider failure, retries disabled | exit `4`; `provider_error`, `ConversationErrorEvent`, and `run.failed` record |
| SIGTERM during hung provider request | exit `143`; atomic `interrupted` summary, 3 partial SDK events, and final interrupt record |

The deterministic endpoint uses a real HTTP transport and the real OpenHands
SDK execution path; it is not used as a substitute for downstream live-model
benchmark validation.

## Verification

- `make lint`
- `make test` (`1,366 passed`)
- `make test-binary` (`3 passed`; existing pytest warnings only)
- targeted pre-commit hooks on every changed file (Ruff format/lint,
  pycodestyle, Pyright)
- disposable Linux source install and no-TTY/offline end-to-end run
- provider-failure and SIGTERM lifecycle runs through the public command

## Compatibility

Existing `openhands`, `openhands --headless`, ACP, web, cloud, and GUI command
paths are unchanged. The new command creates a fresh runtime agent from process
environment values, ignores persisted agent settings, disables the critic, and
uses the SDK's existing process workspace rather than introducing Docker or
another sandbox.

This PR was prepared by Codex on behalf of Kirsten Ruge.